### PR TITLE
chore: Update prosekit

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,7 +38,7 @@
     "next-themes": "^0.4.6",
     "plur": "^5.1.0",
     "plyr-react": "^5.3.0",
-    "prosekit": "^0.11.5",
+    "prosekit": "^0.12.0",
     "rc-slider": "^11.1.8",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",

--- a/apps/web/src/helpers/prosekit/extension.ts
+++ b/apps/web/src/helpers/prosekit/extension.ts
@@ -3,15 +3,13 @@ import { Regex } from "@hey/data/regex";
 import {
   defineBaseCommands,
   defineBaseKeymap,
-  defineDoc,
   defineHistory,
   defineMarkSpec,
   defineNodeSpec,
-  defineParagraph,
-  defineText,
   union
 } from "prosekit/core";
 import { defineBold } from "prosekit/extensions/bold";
+import { defineDoc } from "prosekit/extensions/doc";
 import { defineHeading } from "prosekit/extensions/heading";
 import { defineItalic } from "prosekit/extensions/italic";
 import { defineLinkMarkRule, defineLinkSpec } from "prosekit/extensions/link";
@@ -19,7 +17,9 @@ import { defineMarkRule } from "prosekit/extensions/mark-rule";
 import type { MentionAttrs } from "prosekit/extensions/mention";
 import { defineMentionCommands } from "prosekit/extensions/mention";
 import { defineModClickPrevention } from "prosekit/extensions/mod-click-prevention";
+import { defineParagraph } from "prosekit/extensions/paragraph";
 import { definePlaceholder } from "prosekit/extensions/placeholder";
+import { defineText } from "prosekit/extensions/text";
 import { defineVirtualSelection } from "prosekit/extensions/virtual-selection";
 
 const defineHashtag = () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,8 +267,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0(plyr@3.7.8)(react@19.0.0)
       prosekit:
-        specifier: ^0.11.5
-        version: 0.11.5(@types/hast@3.0.4)(preact@10.26.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: ^0.12.0
+        version: 0.12.0(@shikijs/types@3.2.1)(@types/hast@3.0.4)(preact@10.26.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       rc-slider:
         specifier: ^11.1.8
         version: 11.1.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -661,29 +661,29 @@ packages:
     peerDependencies:
       graphql: '*'
 
-  '@aria-ui/collection@0.0.4':
-    resolution: {integrity: sha512-oEYKE2wyF8HWBvgwBrDjFV6SzL5MCAfq3sahmuM2ShFSXU9BdSKCw7dSCErerbyNIXYPURG44y6B17/HR2BdIw==}
+  '@aria-ui/collection@0.0.5':
+    resolution: {integrity: sha512-loEryFouT9NsQikrk1byv/NAvF6bRTwnjotyc9yaxfRBAjJsajUIlMypKtuMOMvRXgq+dOxmRB5MSbQrgApBTw==}
 
-  '@aria-ui/core@0.0.20':
-    resolution: {integrity: sha512-yZNB4zi5OgDpb6jiQbHjLiYCU0w/hviMDMzdYcdDtbth5jj/9uiQGhommakpHDkhBfGX13ODh6S/y8as5qcoog==}
+  '@aria-ui/core@0.0.21':
+    resolution: {integrity: sha512-b39+C2Ao7QP+bpvBQSFK5Uf/2f+htYo4KSS8BdnoJ/npvVNTXtcyhHPughZGUOHj1gKGvxi+2rdEhGus/UVsNw==}
 
-  '@aria-ui/listbox@0.0.23':
-    resolution: {integrity: sha512-/0aqYxJTIOMKxwtOgngecxBWxhUIcUg7xcq/60vq3x54z/SM07KrWQ8wmlaAlseuPa/FMVpK8bXoPuCi7xIdSA==}
+  '@aria-ui/listbox@0.0.24':
+    resolution: {integrity: sha512-G/qm/EM2B5Pti9lK0W0KPNzDNncX7STKOvWi8MS+obTVn2dM+3f8yH9LGzMNg6rFvj/Bw29xh+hEsTbTzv58fQ==}
 
-  '@aria-ui/menu@0.0.18':
-    resolution: {integrity: sha512-pHLjj2kdQIRPcOKIGqTE8OJ/utFg1AUkN/RKlS5oz07/CZ622NDIVei2OVKYLRDWhE296Ya2K8eoMEbD2j8cUA==}
+  '@aria-ui/menu@0.0.19':
+    resolution: {integrity: sha512-9fU4f9kToqguejaE3KF6sP3CJ9FojQenqJcrfCLUvvtsPrPH1HaFVxb5BZ05yflM0j210PPmZWrxqWKlWg0F5w==}
 
-  '@aria-ui/overlay@0.0.23':
-    resolution: {integrity: sha512-NgJi95mJYZSLOaxjOHLJ46UgFoPdKkHZ7gl4L2L6AiztVPJhlZSzeibZGk1gfckG2qoN3QVCOR7SOk1qbBvhFA==}
+  '@aria-ui/overlay@0.0.24':
+    resolution: {integrity: sha512-kXIzQ7DtRtlSbN1tbT504M1J5HzF0U+ZvEv/f2ONiY3yu7BlZeMKJPF4MXcvl3vQhB/joFyoqXb47OyJvHVkxA==}
 
-  '@aria-ui/popover@0.0.26':
-    resolution: {integrity: sha512-x4H3T2N2GOUEBYxlFg8xXWsCgmoBenW0f1xa+5RjTh6H7slw+OAdXtpQuJu3xraF7d0f1u7DEH9u/1DD5pl+Cw==}
+  '@aria-ui/popover@0.0.27':
+    resolution: {integrity: sha512-PCdKnep3xcB55+N/QLXrB1KaEGDupPmxtQBsU4kZWQGALjgzVOJFK8X8RSL/o8ePddiMQ67WT/krs8axslyeUQ==}
 
-  '@aria-ui/presence@0.0.18':
-    resolution: {integrity: sha512-k2D00F2TG/3BFpOMoNgEVZpjyrUtM8Q5V7KfO73XqbRuFNWMduSvljeR8WGftiDSctvRmjwUDelnnx9tJaat0Q==}
+  '@aria-ui/presence@0.0.19':
+    resolution: {integrity: sha512-YUWo9JmYFhv20XAto85t3N7YDO+f5VoBiDbT77iurOU2ktyFZ1NLrMDh6S6rpDS+k106h0mA5iItpiYHx4kr6Q==}
 
-  '@aria-ui/tooltip@0.0.28':
-    resolution: {integrity: sha512-yezYDg8qv22v2A542M9GYlcgfaivZC3jNn/aDBlBSi4fPZDBOBt5ngl9k7EvpcqNXMIFzpGxtlfrLBmKitG1bw==}
+  '@aria-ui/tooltip@0.0.29':
+    resolution: {integrity: sha512-U1h430e9c9frIHB/3BPUJNpu0PUeY3La99QQPA53Rn2tC+Up9B0MS9arwROOnkpEKfdEzCczlHTyxnLx9wfGdA==}
 
   '@ariatype/aria-attributes-drag-and-drop@1.0.1':
     resolution: {integrity: sha512-C1cZHJuL2e0dhFv0tgyHNPd+WC5oMlzqRxiKQlluyQakWoOoxRIHJbRNd7EajXdu6rwTKgfxZE9ag8gSKnFiKQ==}
@@ -2297,14 +2297,14 @@ packages:
   '@prisma/get-platform@6.5.0':
     resolution: {integrity: sha512-xYcvyJwNMg2eDptBYFqFLUCfgi+wZLcj6HDMsj0Qw0irvauG4IKmkbywnqwok0B+k+W+p+jThM2DKTSmoPCkzw==}
 
-  '@prosekit/basic@0.3.37':
-    resolution: {integrity: sha512-FU6IWZADurbmVWaTXIqFPC3s++fyEwhIJ/mwCGk0CkODHc6mtr7CL7TSxWN4GoCOd4vmtsKi24xzJO+nrqTCvg==}
+  '@prosekit/basic@0.4.0':
+    resolution: {integrity: sha512-Y7XgyDwVHgnkmZiAOw8pfff1vIW/oLMOA5xDBWwfxfxL9xUE7LrVLOPeQFbkxdQExciGFeN/9XZpSgsecOOIPg==}
 
-  '@prosekit/core@0.7.15':
-    resolution: {integrity: sha512-tXrSLxaIsvj84VMQVQWnu0G+4BYqBh4cpnjV+kRmKmTarQvF49izO5drJvD3UaN9TYMB4eCK9Zl4OuNobm5c/w==}
+  '@prosekit/core@0.8.0':
+    resolution: {integrity: sha512-FLijaCx0TEt/zNK9GuwpsjqiHx9FiGDvoOL8rRbHBkWZAKOu8d+1ycIFmgvZrztd9P/w6vfO/eIyGUQ1tOM8Mg==}
 
-  '@prosekit/extensions@0.7.24':
-    resolution: {integrity: sha512-BAXZOxny5tiu2jqnmRpVq6CtYpGHd7NXMky0KhuSyL+ML5Rp6paU8W7Ow5d1CcKhSlYD9DhcoBf6l9HrjhLzFA==}
+  '@prosekit/extensions@0.8.0':
+    resolution: {integrity: sha512-KrFwaQ3nkTpy+zIfXpysv5IbkBpyTqRZFBmq4dlegNl9GPPBrBfZUA1492CcsZmkKtkAQI8W44tbh7Y4LsL1AA==}
     peerDependencies:
       loro-crdt: '>= 0.16.7'
       loro-prosemirror: '>= 0.0.7'
@@ -2320,22 +2320,22 @@ packages:
       yjs:
         optional: true
 
-  '@prosekit/lit@0.4.9':
-    resolution: {integrity: sha512-vp7CTQDkXGZTCUkahC95E0AQ5Ax1GaJ+9tPvPl5Njm/hjbbz3VtgY1dUbohIrWNPBIC2LoDmjc7ZXjf7IKXutg==}
+  '@prosekit/lit@0.4.10':
+    resolution: {integrity: sha512-K3H5InLrp6pmEKMqRf/rRIsFKMMxDd1E6Y0eT2Izdj8IuLN+wV1XNWDllfl6/b/QkWmv9dtYMVZa4W6oZXHv9g==}
 
   '@prosekit/pm@0.1.9':
     resolution: {integrity: sha512-/xJYkIZ3vJHagedDNFjMBrPz8/988jOZNdVLHB/smphvrMqH/l6T8sBgaqfZvVCT6TArGz/ATRk71ub6Qd274w==}
 
-  '@prosekit/preact@0.4.9':
-    resolution: {integrity: sha512-gk8P5mELVC0SRS59lDrIWOsXLVObTeMJATm7+ApnB3IqW3EYDxeUt03Wb4pQVTqBH4GrQmbu5Krc1fVea2T9iA==}
+  '@prosekit/preact@0.4.10':
+    resolution: {integrity: sha512-nLeUBnn+hSqDg5sMQSVucpMFYKpQEgv5YCgh5tNT/FxNWvOriVfWTJ0YHO0rNU0kg7kMZl8dmQUHxXvordGNXA==}
     peerDependencies:
       preact: '>= 10.11.0'
     peerDependenciesMeta:
       preact:
         optional: true
 
-  '@prosekit/react@0.4.10':
-    resolution: {integrity: sha512-yO7+/0yoon3u2bzm5AyQbqSYuZv8oblnaB++o1bhl9R8hQfb7Ku70M5HtHnsPAZYu6++4QRu8n72gigq+9SxRw==}
+  '@prosekit/react@0.4.11':
+    resolution: {integrity: sha512-VOoIJQVrrRQHvTX9e1u/TZGOCoP4rGhNRwaQwbcZnbIzyuj0ODYgW60cazsHfnaJqtLPFdbyz5FCWMoW4uRuJw==}
     peerDependencies:
       react: '>= 18.2.0'
       react-dom: '>= 18.2.0'
@@ -2345,32 +2345,32 @@ packages:
       react-dom:
         optional: true
 
-  '@prosekit/solid@0.4.10':
-    resolution: {integrity: sha512-w7bl2aqRna5IgcAxw/XIPfUCdktWGSUZI82CvlAZDYIxBA7VRrD/l+qdXBPjm4aWtUVSFFK29jsUYuKDVWtr+g==}
+  '@prosekit/solid@0.4.11':
+    resolution: {integrity: sha512-JVb+CizeXds7GAls+YG6iwKrSkCH/IZLV12nLvidXeqoAJgKBq7oSTsjRzDcQ0RiRqA0JPDArw/EpONTudbw7A==}
     peerDependencies:
       solid-js: '>= 1.7.0'
     peerDependenciesMeta:
       solid-js:
         optional: true
 
-  '@prosekit/svelte@0.6.5':
-    resolution: {integrity: sha512-ljJvGAcJr0/zyIiDAicwOmPUueuKYyQ9lSi0qxZAwbizEkCyELdEIvADSzJlVrdJI5wHSrgNojY0ruv7HRQdBw==}
+  '@prosekit/svelte@0.6.6':
+    resolution: {integrity: sha512-bCYa5AaBUD9JtttSFfd67mjE1PnVawptA0qExImu5QgLLkYVJPVL6rhd3vX7bu1aeTCKbGaAcuqjdIx7PxywwA==}
     peerDependencies:
       svelte: '>= 5.0.0'
     peerDependenciesMeta:
       svelte:
         optional: true
 
-  '@prosekit/vue@0.4.10':
-    resolution: {integrity: sha512-u9n4JwtGlpVhdQvQjKLou/5yXzL+IpqyFUKrKM4MBxcKcOBdeJlHUj3mCOVGLiA6VimPSXTjVOI14K+NOdcAkA==}
+  '@prosekit/vue@0.4.11':
+    resolution: {integrity: sha512-3rlD/F1RWUnibaYPA5sFz08KE8PoD0SXCDRYNGB7wu45It1KK0WJwr3sMtb4pZLhQ8lNgfV+iDK8aVh3PAa1XA==}
     peerDependencies:
       vue: '>= 3.0.0'
     peerDependenciesMeta:
       vue:
         optional: true
 
-  '@prosekit/web@0.5.5':
-    resolution: {integrity: sha512-woRR2hJ3GTW0x/M7ks87xrWCsPCt+5f+4HGirR7AO3O+DQilbE3KYHIJYQgJcSM1q/7sIkGe32CvSLYcFlb/cw==}
+  '@prosekit/web@0.5.6':
+    resolution: {integrity: sha512-BxpSDhUSCLD2cokAFMM8/gZvSFiUIXQx48guapD2L/mHgqy2P4fxZOvAPOeLPFsu5M+Qn+nbUcPO0qP24TIG0g==}
 
   '@prosemirror-adapter/core@0.4.0':
     resolution: {integrity: sha512-feLFTIvbpQDnWspZv+rjTPmqpeJ8++VM/gDnBaDNLsAEvrwmO1IHc0oyrRBl/9x3Er3tU/WXc86TlOidsN1aEg==}
@@ -2854,23 +2854,23 @@ packages:
   '@scure/bip39@1.5.4':
     resolution: {integrity: sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==}
 
-  '@shikijs/core@1.29.2':
-    resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
+  '@shikijs/core@3.2.1':
+    resolution: {integrity: sha512-FhsdxMWYu/C11sFisEp7FMGBtX/OSSbnXZDMBhGuUDBNTdsoZlMSgQv5f90rwvzWAdWIW6VobD+G3IrazxA6dQ==}
 
-  '@shikijs/engine-javascript@1.29.2':
-    resolution: {integrity: sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==}
+  '@shikijs/engine-javascript@3.2.1':
+    resolution: {integrity: sha512-eMdcUzN3FMQYxOmRf2rmU8frikzoSHbQDFH2hIuXsrMO+IBOCI9BeeRkCiBkcLDHeRKbOCtYMJK3D6U32ooU9Q==}
 
-  '@shikijs/engine-oniguruma@1.29.2':
-    resolution: {integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==}
+  '@shikijs/engine-oniguruma@3.2.1':
+    resolution: {integrity: sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==}
 
-  '@shikijs/langs@1.29.2':
-    resolution: {integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==}
+  '@shikijs/langs@3.2.1':
+    resolution: {integrity: sha512-If0iDHYRSGbihiA8+7uRsgb1er1Yj11pwpX1c6HLYnizDsKAw5iaT3JXj5ZpaimXSWky/IhxTm7C6nkiYVym+A==}
 
-  '@shikijs/themes@1.29.2':
-    resolution: {integrity: sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==}
+  '@shikijs/themes@3.2.1':
+    resolution: {integrity: sha512-k5DKJUT8IldBvAm8WcrDT5+7GA7se6lLksR+2E3SvyqGTyFMzU2F9Gb7rmD+t+Pga1MKrYFxDIeyWjMZWM6uBQ==}
 
-  '@shikijs/types@1.29.2':
-    resolution: {integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==}
+  '@shikijs/types@3.2.1':
+    resolution: {integrity: sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -3416,35 +3416,20 @@ packages:
     resolution: {integrity: sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==}
     engines: {node: '>=8'}
 
-  '@zag-js/dismissable@0.80.0':
-    resolution: {integrity: sha512-7qTsEzSKYH8tAAndWLiT0A09zg8TYUaaldvtpc/rtO/C/fzN2PkEkXo17IiNvRFjDo/GjjQ2IAx3E2BXRP64ow==}
+  '@zag-js/dismissable@1.4.2':
+    resolution: {integrity: sha512-lFVZk5WR/nIIz+WczzZtqTPRACKw2bIlpz8bm7P5dj3h7gTo4citC9xE2h2dXBNiMz05wKBBb2wSDDmlS9377g==}
 
-  '@zag-js/dom-event@0.80.0':
-    resolution: {integrity: sha512-dWOGfsVxobT3qCjadyBfZhV0DxpbhZD23N4luPi1mEd1eSfvw0dJlkRDDare0TQnkbUL90+pTqTt2epzxJvGxw==}
+  '@zag-js/dom-query@1.4.2':
+    resolution: {integrity: sha512-F6261rPnyOJgM3KKR08dqBQH5XbN/NZN60h2zwJN6EeZTGRQlNvC3JAK3Qpdu0+zd0/2DvQA0CnbWfMMz0mmQw==}
 
-  '@zag-js/dom-query@0.79.3':
-    resolution: {integrity: sha512-PMa5aEx71lP4i/Ip+YEtV7vDUu6QuLEyQF3UiO+tj0ijbmjZDVENERv7btVG0+ej+xhLlybdYwcTvTX6W3OvDA==}
+  '@zag-js/interact-outside@1.4.2':
+    resolution: {integrity: sha512-L5FEo+CZtzN1FoD1jJlQWNH7qiQUOiCYZs37Fvh49CTPeDZTc2q8Ho7qB4qNQQfvXNMLWlI8wqrDWAogCMX01g==}
 
-  '@zag-js/dom-query@0.80.0':
-    resolution: {integrity: sha512-wDIMR/KnDmUOswCnsvtN0V67quFnIE31x6LqeaQS9g0ZqMC+AkbGo6zRlIzzvxIHa5uc6ee/FFn/TBZ5Cfd1KQ==}
+  '@zag-js/types@1.4.2':
+    resolution: {integrity: sha512-CvjVZVKqSRkChivt/Bu5hr5+v8bYKM9OZmvIB7vQj5BZOsh9qBhgvPvCSZ71VQb82rykzFULhJKaKP7ROUY46w==}
 
-  '@zag-js/dom-query@0.81.2':
-    resolution: {integrity: sha512-Iqi84Ac+5G8PUSETdJFG4eQ+g+Ami/IKxpTmYBdpPZWzgg82hD/+DQ5dDFndQc5HLfo1uhJVZy8O7z8gTrr0Sg==}
-
-  '@zag-js/interact-outside@0.80.0':
-    resolution: {integrity: sha512-v2FpIkx3SqrXvkaKdIVrsCpE5y8U9QU0WOdyAKp2iPMM7YeqB+dbHuA7ceOaJr2e9DqW0PQI/qllbhmkTCcQlg==}
-
-  '@zag-js/text-selection@0.80.0':
-    resolution: {integrity: sha512-W5kfPN9Pz5KzSCHCr0oUofzDWGxHQRlLq26DTQJVw5dwByEXR27UyNTDtaYFdHr+duVIFLueKlAvOieNWc1MDg==}
-
-  '@zag-js/types@0.80.0':
-    resolution: {integrity: sha512-SpaV+uU2FV5qhtaJxfaPWuEBijzPMiElE7X3R5D9hDP0q7iHSuG0h/C0TDLGXLReV+y/YNlYVUUnZSHOv8ZNXQ==}
-
-  '@zag-js/types@0.81.2':
-    resolution: {integrity: sha512-RmEN7+TrpJiS1NLqTvURmxhYyCrsuLKblbdR/MSJ2L0M0sdncyClSNhcXkjSd0wRuEaNPF97H5lvAhQ+nEMynQ==}
-
-  '@zag-js/utils@0.80.0':
-    resolution: {integrity: sha512-+GXVHO0pfCENjcYz6CKI+YbMHNnSGCLsRIXrpbvU1tYeTk0L1tniAKzQ87vkZMkdYbbkg96MFvjexbq0foGwAQ==}
+  '@zag-js/utils@1.4.2':
+    resolution: {integrity: sha512-/B2sCmkDv3VO6+tzXF8+w6is6nr1uwBLgZmeJa7HTithRTVVYyUPGGqn1fQ9ibOS2potQz6geMmfwzVGopCw/Q==}
 
   abitype@1.0.8:
     resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
@@ -5580,8 +5565,11 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
-  oniguruma-to-es@2.3.0:
-    resolution: {integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==}
+  oniguruma-parser@0.5.4:
+    resolution: {integrity: sha512-yNxcQ8sKvURiTwP0mV6bLQCYE7NKfKRRWunhbZnXgxSmB1OXa1lHrN3o4DZd+0Si0kU5blidK7BcROO8qv5TZA==}
+
+  oniguruma-to-es@4.1.0:
+    resolution: {integrity: sha512-SNwG909cSLo4vPyyPbU/VJkEc9WOXqu2ycBlfd1UCXLqk1IijcQktSBb2yRQ2UFPsDhpkaf+C1dtT3PkLK/yWA==}
 
   open@9.1.0:
     resolution: {integrity: sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==}
@@ -5860,8 +5848,8 @@ packages:
   property-information@7.0.0:
     resolution: {integrity: sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==}
 
-  prosekit@0.11.5:
-    resolution: {integrity: sha512-h3JBq+eIfE3ethUei5IeJFqj5PWCJv4sKJ4i3SPDny9F+fvDBpuUiBBClKYtMY+oZgjp5Z7Ai9nNudVvWHTpBg==}
+  prosekit@0.12.0:
+    resolution: {integrity: sha512-RnvQNaUVjxTi3hmIrysnqrUgJgNzerywHiJJLyL8j1dWNJUXj9ELZGKiTIh1BOvTfjBfJp7iX/iFbl9mUB5ZUw==}
     peerDependencies:
       loro-crdt: '>= 0.16.7'
       loro-prosemirror: '>= 0.0.7'
@@ -5910,9 +5898,10 @@ packages:
   prosemirror-gapcursor@1.3.2:
     resolution: {integrity: sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==}
 
-  prosemirror-highlight@0.11.1:
-    resolution: {integrity: sha512-ZfTWNjIuutHbKccIBZZcpeTAoZqYlecPyhw52H9YtxaaRzmWahC0y2TVhi8TXm2Y10qNxoIzRXuyl0bAmZfxag==}
+  prosemirror-highlight@0.13.0:
+    resolution: {integrity: sha512-GIC2VCTUnukNdsEGLQWWOVpYPl/7/KrVp4xs7XMB48/4rhUrHK8hp8TEog4Irmv+2kmjx24RLnaisGOCP6U8jw==}
     peerDependencies:
+      '@shikijs/types': ^1.29.2 || ^2.0.0 || ^3.0.0
       '@types/hast': ^3.0.0
       highlight.js: ^11.9.0
       lowlight: ^3.1.0
@@ -5920,10 +5909,11 @@ packages:
       prosemirror-state: ^1.4.3
       prosemirror-transform: ^1.8.0
       prosemirror-view: ^1.32.4
-      refractor: ^4.8.1
-      shiki: ^1.9.0 || ^2.0.0
-      sugar-high: ^0.6.1 || ^0.7.0 || ^0.8.0
+      refractor: ^5.0.0
+      sugar-high: ^0.6.1 || ^0.7.0 || ^0.8.0 || ^0.9.0
     peerDependenciesMeta:
+      '@shikijs/types':
+        optional: true
       '@types/hast':
         optional: true
       highlight.js:
@@ -5939,8 +5929,6 @@ packages:
       prosemirror-view:
         optional: true
       refractor:
-        optional: true
-      shiki:
         optional: true
       sugar-high:
         optional: true
@@ -6216,14 +6204,14 @@ packages:
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
-  regex-recursion@5.1.1:
-    resolution: {integrity: sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==}
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
   regex-utilities@2.3.0:
     resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
 
-  regex@5.1.1:
-    resolution: {integrity: sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==}
+  regex@6.0.1:
+    resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
 
   rehackt@0.1.0:
     resolution: {integrity: sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==}
@@ -6419,8 +6407,8 @@ packages:
     resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
     engines: {node: '>= 0.4'}
 
-  shiki@1.29.2:
-    resolution: {integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==}
+  shiki@3.2.1:
+    resolution: {integrity: sha512-VML/2o1/KGYkEf/stJJ+s9Ypn7jUKQPomGLGYso4JJFMFxVDyPNsjsI3MB3KLjlMOeH44gyaPdXC6rik2WXvUQ==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -7401,59 +7389,59 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@aria-ui/collection@0.0.4': {}
+  '@aria-ui/collection@0.0.5': {}
 
-  '@aria-ui/core@0.0.20':
+  '@aria-ui/core@0.0.21':
     dependencies:
       '@ariatype/aria-attributes': 1.0.1
       '@ariatype/aria-roles': 1.0.1
       '@preact/signals-core': 1.8.0
-      '@zag-js/dom-query': 0.79.3
+      '@zag-js/dom-query': 1.4.2
       just-kebab-case: 4.2.0
       just-map-values: 3.2.0
       server-dom-shim: 1.0.2
 
-  '@aria-ui/listbox@0.0.23':
+  '@aria-ui/listbox@0.0.24':
     dependencies:
-      '@aria-ui/collection': 0.0.4
-      '@aria-ui/core': 0.0.20
-      '@aria-ui/presence': 0.0.18
+      '@aria-ui/collection': 0.0.5
+      '@aria-ui/core': 0.0.21
+      '@aria-ui/presence': 0.0.19
       immer: 10.1.1
 
-  '@aria-ui/menu@0.0.18':
+  '@aria-ui/menu@0.0.19':
     dependencies:
-      '@aria-ui/collection': 0.0.4
-      '@aria-ui/core': 0.0.20
-      '@aria-ui/overlay': 0.0.23
-      '@aria-ui/popover': 0.0.26
-      '@aria-ui/presence': 0.0.18
+      '@aria-ui/collection': 0.0.5
+      '@aria-ui/core': 0.0.21
+      '@aria-ui/overlay': 0.0.24
+      '@aria-ui/popover': 0.0.27
+      '@aria-ui/presence': 0.0.19
       nanoid: 5.1.5
 
-  '@aria-ui/overlay@0.0.23':
+  '@aria-ui/overlay@0.0.24':
     dependencies:
-      '@aria-ui/core': 0.0.20
+      '@aria-ui/core': 0.0.21
       '@floating-ui/dom': 1.6.13
       '@floating-ui/utils': 0.2.9
-      '@zag-js/dom-query': 0.79.3
+      '@zag-js/dom-query': 1.4.2
 
-  '@aria-ui/popover@0.0.26':
+  '@aria-ui/popover@0.0.27':
     dependencies:
-      '@aria-ui/core': 0.0.20
-      '@aria-ui/overlay': 0.0.23
-      '@aria-ui/presence': 0.0.18
-      '@zag-js/dismissable': 0.80.0
-      '@zag-js/dom-query': 0.80.0
+      '@aria-ui/core': 0.0.21
+      '@aria-ui/overlay': 0.0.24
+      '@aria-ui/presence': 0.0.19
+      '@zag-js/dismissable': 1.4.2
+      '@zag-js/dom-query': 1.4.2
 
-  '@aria-ui/presence@0.0.18':
+  '@aria-ui/presence@0.0.19':
     dependencies:
-      '@aria-ui/core': 0.0.20
-      '@zag-js/dom-query': 0.80.0
+      '@aria-ui/core': 0.0.21
+      '@zag-js/dom-query': 1.4.2
 
-  '@aria-ui/tooltip@0.0.28':
+  '@aria-ui/tooltip@0.0.29':
     dependencies:
-      '@aria-ui/core': 0.0.20
-      '@aria-ui/overlay': 0.0.23
-      '@aria-ui/presence': 0.0.18
+      '@aria-ui/core': 0.0.21
+      '@aria-ui/overlay': 0.0.24
+      '@aria-ui/presence': 0.0.19
       nanoid: 5.1.5
 
   '@ariatype/aria-attributes-drag-and-drop@1.0.1': {}
@@ -9811,12 +9799,13 @@ snapshots:
     dependencies:
       '@prisma/debug': 6.5.0
 
-  '@prosekit/basic@0.3.37(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
+  '@prosekit/basic@0.4.0(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
     dependencies:
-      '@prosekit/core': 0.7.15(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
-      '@prosekit/extensions': 0.7.24(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/core': 0.8.0(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
+      '@prosekit/extensions': 0.8.0(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
       '@prosekit/pm': 0.1.9
     transitivePeerDependencies:
+      - '@shikijs/types'
       - '@types/hast'
       - highlight.js
       - loro-crdt
@@ -9831,7 +9820,7 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@prosekit/core@0.7.15(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)':
+  '@prosekit/core@0.8.0(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)':
     dependencies:
       '@prosekit/pm': 0.1.9
       clsx: 2.1.1
@@ -9845,19 +9834,20 @@ snapshots:
       - prosemirror-state
       - prosemirror-transform
 
-  '@prosekit/extensions@0.7.24(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
+  '@prosekit/extensions@0.8.0(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
     dependencies:
-      '@prosekit/core': 0.7.15(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
+      '@prosekit/core': 0.8.0(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
       '@prosekit/pm': 0.1.9
       prosemirror-changeset: 2.2.1
       prosemirror-dropcursor: 1.8.1
       prosemirror-flat-list: 0.5.4
       prosemirror-gapcursor: 1.3.2
-      prosemirror-highlight: 0.11.1(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)(shiki@1.29.2)
+      prosemirror-highlight: 0.13.0(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
       prosemirror-search: 1.0.0
       prosemirror-tables: 1.6.4
-      shiki: 1.29.2
+      shiki: 3.2.1
     transitivePeerDependencies:
+      - '@shikijs/types'
       - '@types/hast'
       - highlight.js
       - lowlight
@@ -9868,10 +9858,11 @@ snapshots:
       - refractor
       - sugar-high
 
-  '@prosekit/lit@0.4.9(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
+  '@prosekit/lit@0.4.10(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
     dependencies:
-      '@prosekit/web': 0.5.5(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/web': 0.5.6(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
     transitivePeerDependencies:
+      - '@shikijs/types'
       - '@types/hast'
       - highlight.js
       - loro-crdt
@@ -9897,15 +9888,16 @@ snapshots:
       prosemirror-transform: 1.10.3
       prosemirror-view: 1.38.1
 
-  '@prosekit/preact@0.4.9(@types/hast@3.0.4)(preact@10.26.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
+  '@prosekit/preact@0.4.10(@shikijs/types@3.2.1)(@types/hast@3.0.4)(preact@10.26.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
     dependencies:
-      '@prosekit/core': 0.7.15(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
+      '@prosekit/core': 0.8.0(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
       '@prosekit/pm': 0.1.9
-      '@prosekit/web': 0.5.5(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/web': 0.5.6(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
       react-merge-refs: 2.1.1
     optionalDependencies:
       preact: 10.26.4
     transitivePeerDependencies:
+      - '@shikijs/types'
       - '@types/hast'
       - highlight.js
       - loro-crdt
@@ -9920,11 +9912,11 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@prosekit/react@0.4.10(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@prosekit/react@0.4.11(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@prosekit/core': 0.7.15(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
+      '@prosekit/core': 0.8.0(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
       '@prosekit/pm': 0.1.9
-      '@prosekit/web': 0.5.5(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/web': 0.5.6(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
       '@prosemirror-adapter/core': 0.4.0
       '@prosemirror-adapter/react': 0.4.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-merge-refs: 2.1.1
@@ -9932,6 +9924,7 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     transitivePeerDependencies:
+      - '@shikijs/types'
       - '@types/hast'
       - highlight.js
       - loro-crdt
@@ -9946,14 +9939,15 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@prosekit/solid@0.4.10(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
+  '@prosekit/solid@0.4.11(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
     dependencies:
-      '@prosekit/core': 0.7.15(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
+      '@prosekit/core': 0.8.0(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
       '@prosekit/pm': 0.1.9
-      '@prosekit/web': 0.5.5(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/web': 0.5.6(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
       '@prosemirror-adapter/core': 0.4.0
       '@prosemirror-adapter/solid': 0.4.1
     transitivePeerDependencies:
+      - '@shikijs/types'
       - '@types/hast'
       - highlight.js
       - loro-crdt
@@ -9968,14 +9962,15 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@prosekit/svelte@0.6.5(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
+  '@prosekit/svelte@0.6.6(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
     dependencies:
-      '@prosekit/core': 0.7.15(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
+      '@prosekit/core': 0.8.0(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
       '@prosekit/pm': 0.1.9
-      '@prosekit/web': 0.5.5(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/web': 0.5.6(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
       '@prosemirror-adapter/core': 0.4.0
       '@prosemirror-adapter/svelte': 0.4.1
     transitivePeerDependencies:
+      - '@shikijs/types'
       - '@types/hast'
       - highlight.js
       - loro-crdt
@@ -9990,14 +9985,15 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@prosekit/vue@0.4.10(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
+  '@prosekit/vue@0.4.11(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
     dependencies:
-      '@prosekit/core': 0.7.15(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
+      '@prosekit/core': 0.8.0(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
       '@prosekit/pm': 0.1.9
-      '@prosekit/web': 0.5.5(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/web': 0.5.6(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
       '@prosemirror-adapter/core': 0.4.0
       '@prosemirror-adapter/vue': 0.4.1
     transitivePeerDependencies:
+      - '@shikijs/types'
       - '@types/hast'
       - highlight.js
       - loro-crdt
@@ -10012,25 +10008,26 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@prosekit/web@0.5.5(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
+  '@prosekit/web@0.5.6(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)':
     dependencies:
-      '@aria-ui/collection': 0.0.4
-      '@aria-ui/core': 0.0.20
-      '@aria-ui/listbox': 0.0.23
-      '@aria-ui/menu': 0.0.18
-      '@aria-ui/overlay': 0.0.23
-      '@aria-ui/popover': 0.0.26
-      '@aria-ui/presence': 0.0.18
-      '@aria-ui/tooltip': 0.0.28
+      '@aria-ui/collection': 0.0.5
+      '@aria-ui/core': 0.0.21
+      '@aria-ui/listbox': 0.0.24
+      '@aria-ui/menu': 0.0.19
+      '@aria-ui/overlay': 0.0.24
+      '@aria-ui/popover': 0.0.27
+      '@aria-ui/presence': 0.0.19
+      '@aria-ui/tooltip': 0.0.29
       '@floating-ui/dom': 1.6.13
-      '@prosekit/core': 0.7.15(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
-      '@prosekit/extensions': 0.7.24(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/core': 0.8.0(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
+      '@prosekit/extensions': 0.8.0(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
       '@prosekit/pm': 0.1.9
-      '@zag-js/dom-query': 0.81.2
+      '@zag-js/dom-query': 1.4.2
       just-map-values: 3.2.0
       just-omit: 2.2.0
       prosemirror-tables: 1.6.4
     transitivePeerDependencies:
+      - '@shikijs/types'
       - '@types/hast'
       - highlight.js
       - loro-crdt
@@ -10546,35 +10543,33 @@ snapshots:
       '@noble/hashes': 1.7.1
       '@scure/base': 1.2.4
 
-  '@shikijs/core@1.29.2':
+  '@shikijs/core@3.2.1':
     dependencies:
-      '@shikijs/engine-javascript': 1.29.2
-      '@shikijs/engine-oniguruma': 1.29.2
-      '@shikijs/types': 1.29.2
+      '@shikijs/types': 3.2.1
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
-  '@shikijs/engine-javascript@1.29.2':
+  '@shikijs/engine-javascript@3.2.1':
     dependencies:
-      '@shikijs/types': 1.29.2
+      '@shikijs/types': 3.2.1
       '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 2.3.0
+      oniguruma-to-es: 4.1.0
 
-  '@shikijs/engine-oniguruma@1.29.2':
+  '@shikijs/engine-oniguruma@3.2.1':
     dependencies:
-      '@shikijs/types': 1.29.2
+      '@shikijs/types': 3.2.1
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@1.29.2':
+  '@shikijs/langs@3.2.1':
     dependencies:
-      '@shikijs/types': 1.29.2
+      '@shikijs/types': 3.2.1
 
-  '@shikijs/themes@1.29.2':
+  '@shikijs/themes@3.2.1':
     dependencies:
-      '@shikijs/types': 1.29.2
+      '@shikijs/types': 3.2.1
 
-  '@shikijs/types@1.29.2':
+  '@shikijs/types@3.2.1':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -11577,46 +11572,26 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@zag-js/dismissable@0.80.0':
+  '@zag-js/dismissable@1.4.2':
     dependencies:
-      '@zag-js/dom-event': 0.80.0
-      '@zag-js/dom-query': 0.80.0
-      '@zag-js/interact-outside': 0.80.0
-      '@zag-js/utils': 0.80.0
+      '@zag-js/dom-query': 1.4.2
+      '@zag-js/interact-outside': 1.4.2
+      '@zag-js/utils': 1.4.2
 
-  '@zag-js/dom-event@0.80.0':
+  '@zag-js/dom-query@1.4.2':
     dependencies:
-      '@zag-js/dom-query': 0.80.0
-      '@zag-js/text-selection': 0.80.0
-      '@zag-js/types': 0.80.0
+      '@zag-js/types': 1.4.2
 
-  '@zag-js/dom-query@0.79.3': {}
-
-  '@zag-js/dom-query@0.80.0': {}
-
-  '@zag-js/dom-query@0.81.2':
+  '@zag-js/interact-outside@1.4.2':
     dependencies:
-      '@zag-js/types': 0.81.2
+      '@zag-js/dom-query': 1.4.2
+      '@zag-js/utils': 1.4.2
 
-  '@zag-js/interact-outside@0.80.0':
-    dependencies:
-      '@zag-js/dom-event': 0.80.0
-      '@zag-js/dom-query': 0.80.0
-      '@zag-js/utils': 0.80.0
-
-  '@zag-js/text-selection@0.80.0':
-    dependencies:
-      '@zag-js/dom-query': 0.80.0
-
-  '@zag-js/types@0.80.0':
+  '@zag-js/types@1.4.2':
     dependencies:
       csstype: 3.1.3
 
-  '@zag-js/types@0.81.2':
-    dependencies:
-      csstype: 3.1.3
-
-  '@zag-js/utils@0.80.0': {}
+  '@zag-js/utils@1.4.2': {}
 
   abitype@1.0.8(typescript@5.8.2)(zod@3.24.2):
     optionalDependencies:
@@ -14083,11 +14058,14 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
-  oniguruma-to-es@2.3.0:
+  oniguruma-parser@0.5.4: {}
+
+  oniguruma-to-es@4.1.0:
     dependencies:
       emoji-regex-xs: 1.0.0
-      regex: 5.1.1
-      regex-recursion: 5.1.1
+      oniguruma-parser: 0.5.4
+      regex: 6.0.1
+      regex-recursion: 6.0.2
 
   open@9.1.0:
     dependencies:
@@ -14414,24 +14392,25 @@ snapshots:
 
   property-information@7.0.0: {}
 
-  prosekit@0.11.5(@types/hast@3.0.4)(preact@10.26.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  prosekit@0.12.0(@shikijs/types@3.2.1)(@types/hast@3.0.4)(preact@10.26.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      '@prosekit/basic': 0.3.37(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
-      '@prosekit/core': 0.7.15(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
-      '@prosekit/extensions': 0.7.24(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
-      '@prosekit/lit': 0.4.9(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/basic': 0.4.0(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/core': 0.8.0(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)
+      '@prosekit/extensions': 0.8.0(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/lit': 0.4.10(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
       '@prosekit/pm': 0.1.9
-      '@prosekit/preact': 0.4.9(@types/hast@3.0.4)(preact@10.26.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
-      '@prosekit/react': 0.4.10(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@prosekit/solid': 0.4.10(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
-      '@prosekit/svelte': 0.6.5(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
-      '@prosekit/vue': 0.4.10(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
-      '@prosekit/web': 0.5.5(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/preact': 0.4.10(@shikijs/types@3.2.1)(@types/hast@3.0.4)(preact@10.26.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/react': 0.4.11(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@prosekit/solid': 0.4.11(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/svelte': 0.6.6(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/vue': 0.4.11(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
+      '@prosekit/web': 0.5.6(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)
     optionalDependencies:
       preact: 10.26.4
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     transitivePeerDependencies:
+      - '@shikijs/types'
       - '@types/hast'
       - highlight.js
       - lowlight
@@ -14475,14 +14454,14 @@ snapshots:
       prosemirror-state: 1.4.3
       prosemirror-view: 1.38.1
 
-  prosemirror-highlight@0.11.1(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1)(shiki@1.29.2):
+  prosemirror-highlight@0.13.0(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.0)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.3)(prosemirror-view@1.38.1):
     optionalDependencies:
+      '@shikijs/types': 3.2.1
       '@types/hast': 3.0.4
       prosemirror-model: 1.25.0
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.3
       prosemirror-view: 1.38.1
-      shiki: 1.29.2
 
   prosemirror-history@1.4.1:
     dependencies:
@@ -14776,14 +14755,13 @@ snapshots:
 
   regenerator-runtime@0.14.1: {}
 
-  regex-recursion@5.1.1:
+  regex-recursion@6.0.2:
     dependencies:
-      regex: 5.1.1
       regex-utilities: 2.3.0
 
   regex-utilities@2.3.0: {}
 
-  regex@5.1.1:
+  regex@6.0.1:
     dependencies:
       regex-utilities: 2.3.0
 
@@ -15037,14 +15015,14 @@ snapshots:
 
   shell-quote@1.8.2: {}
 
-  shiki@1.29.2:
+  shiki@3.2.1:
     dependencies:
-      '@shikijs/core': 1.29.2
-      '@shikijs/engine-javascript': 1.29.2
-      '@shikijs/engine-oniguruma': 1.29.2
-      '@shikijs/langs': 1.29.2
-      '@shikijs/themes': 1.29.2
-      '@shikijs/types': 1.29.2
+      '@shikijs/core': 3.2.1
+      '@shikijs/engine-javascript': 3.2.1
+      '@shikijs/engine-oniguruma': 3.2.1
+      '@shikijs/langs': 3.2.1
+      '@shikijs/themes': 3.2.1
+      '@shikijs/types': 3.2.1
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 


### PR DESCRIPTION
Update `prosekit` to the latest v0.12.0. Some noticeable changes are listed below:

- The import paths for some APIs have changed, which is already addressed in the PR.

- Small breaking changes: The keyboard shortcuts for toggling heading have changed from `Command-1` ... `Command-6` to `Command-Option-1` ... `Command-Option-6`. These new keyboard shortcuts match existing popular editors (e.g. Google docs, Notion) better, and they don't conflict with browsers' tab switching keyboard shortcuts. 

  I can bring back old keyboard shortcuts for hey.xyz if you want. 

- New keyboard shortcut: `Command-Option-0` to turn a heading into a paragraph. This also matches other editors like Google docs. 

