### PR TITLE
refactor: migrate to fetch from axios

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,7 +22,6 @@
     "@hono/zod-validator": "^0.4.3",
     "@lens-protocol/metadata": "^2.0.0",
     "@prisma/client": "^6.6.0",
-    "axios": "^1.8.4",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "graphql": "^16.10.0",

--- a/apps/api/src/routes/oembed/helpers/getMetadata.ts
+++ b/apps/api/src/routes/oembed/helpers/getMetadata.ts
@@ -8,6 +8,10 @@ const fetchData = async (url: string) => {
     headers: { "User-Agent": HEY_USER_AGENT }
   });
 
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
+  }
+
   return await response.text();
 };
 

--- a/apps/api/src/routes/oembed/helpers/getMetadata.ts
+++ b/apps/api/src/routes/oembed/helpers/getMetadata.ts
@@ -1,14 +1,14 @@
-import axios from "axios";
 import { parseHTML } from "linkedom";
 import { HEY_USER_AGENT } from "../../../helpers/constants";
 import getDescription from "./meta/getDescription";
 import getTitle from "./meta/getTitle";
 
 const fetchData = async (url: string) => {
-  const { data } = await axios.get(url, {
+  const response = await fetch(url, {
     headers: { "User-Agent": HEY_USER_AGENT }
   });
-  return data;
+
+  return await response.text();
 };
 
 const extractMetadata = (document: Document, url: string) => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,6 @@
     "@tailwindcss/vite": "^4.1.3",
     "@tanstack/react-query": "^5.73.3",
     "@uidotdev/usehooks": "^2.4.1",
-    "axios": "^1.8.4",
     "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/components/Composer/Actions/Gif/Categories.tsx
+++ b/apps/web/src/components/Composer/Actions/Gif/Categories.tsx
@@ -17,6 +17,10 @@ const Categories = ({ setSearchText }: CategoriesProps) => {
         `https://api.giphy.com/v1/gifs/categories?api_key=${GIPHY_KEY}`
       );
 
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+
       const data = await response.json();
       return data.data;
     } catch {

--- a/apps/web/src/components/Composer/Actions/Gif/Categories.tsx
+++ b/apps/web/src/components/Composer/Actions/Gif/Categories.tsx
@@ -2,7 +2,6 @@ import { H5 } from "@/components/Shared/UI";
 import { GIPHY_KEY } from "@hey/data/constants";
 import type { Category } from "@hey/types/giphy";
 import { useQuery } from "@tanstack/react-query";
-import axios from "axios";
 import type { Dispatch, SetStateAction } from "react";
 
 const GET_GIPHY_CATEGORIES_QUERY_KEY = "getGiphyCategories";
@@ -14,11 +13,11 @@ interface CategoriesProps {
 const Categories = ({ setSearchText }: CategoriesProps) => {
   const getGiphyCategories = async () => {
     try {
-      const { data } = await axios.get(
-        "https://api.giphy.com/v1/gifs/categories",
-        { params: { api_key: GIPHY_KEY } }
+      const response = await fetch(
+        `https://api.giphy.com/v1/gifs/categories?api_key=${GIPHY_KEY}`
       );
 
+      const data = await response.json();
       return data.data;
     } catch {
       return [];

--- a/apps/web/src/components/Composer/Actions/Gif/Gifs.tsx
+++ b/apps/web/src/components/Composer/Actions/Gif/Gifs.tsx
@@ -30,6 +30,10 @@ const Gifs = ({
         `https://api.giphy.com/v1/gifs/search?api_key=${GIPHY_KEY}&limit=48&q=${encodeURIComponent(input)}`
       );
 
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+
       const data = await response.json();
       return data.data;
     } catch {

--- a/apps/web/src/components/Composer/Actions/Gif/Gifs.tsx
+++ b/apps/web/src/components/Composer/Actions/Gif/Gifs.tsx
@@ -1,7 +1,6 @@
 import { GIPHY_KEY } from "@hey/data/constants";
 import type { IGif } from "@hey/types/giphy";
 import { useQuery } from "@tanstack/react-query";
-import axios from "axios";
 import type { Dispatch, SetStateAction } from "react";
 
 const GET_GIFS_QUERY_KEY = "getGifs";
@@ -27,10 +26,11 @@ const Gifs = ({
 
   const getGifs = async (input: string): Promise<IGif[]> => {
     try {
-      const { data } = await axios.get("https://api.giphy.com/v1/gifs/search", {
-        params: { api_key: GIPHY_KEY, limit: 48, q: input }
-      });
+      const response = await fetch(
+        `https://api.giphy.com/v1/gifs/search?api_key=${GIPHY_KEY}&limit=48&q=${encodeURIComponent(input)}`
+      );
 
+      const data = await response.json();
       return data.data;
     } catch {
       return [];

--- a/apps/web/src/helpers/authLink.ts
+++ b/apps/web/src/helpers/authLink.ts
@@ -7,7 +7,6 @@ import { ApolloLink, fromPromise, toPromise } from "@apollo/client";
 import { LENS_API_URL } from "@hey/data/constants";
 import parseJwt from "@hey/helpers/parseJwt";
 import type { RefreshResult } from "@hey/indexer";
-import axios from "axios";
 
 const REFRESH_AUTHENTICATION_MUTATION = `
   mutation Refresh($request: RefreshRequest!) {
@@ -31,16 +30,21 @@ const executeTokenRefresh = async (
   attempt = 0
 ): Promise<string> => {
   try {
-    const { data } = await axios.post(
-      LENS_API_URL,
-      {
+    const response = await fetch(LENS_API_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
         operationName: "Refresh",
         query: REFRESH_AUTHENTICATION_MUTATION,
         variables: { request: { refreshToken } }
-      },
-      { headers: { "Content-Type": "application/json" } }
-    );
+      })
+    });
 
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const data = await response.json();
     const refreshResult = data?.data?.refresh as RefreshResult;
 
     if (!refreshResult) {

--- a/apps/web/src/helpers/authLink.ts
+++ b/apps/web/src/helpers/authLink.ts
@@ -41,7 +41,7 @@ const executeTokenRefresh = async (
     });
 
     if (!response.ok) {
-      executeTokenRefresh(refreshToken, attempt + 1);
+      await executeTokenRefresh(refreshToken, attempt + 1);
     }
 
     const data = await response.json();
@@ -79,7 +79,7 @@ const executeTokenRefresh = async (
     }
 
     if (attempt < MAX_RETRIES) {
-      return executeTokenRefresh(refreshToken, attempt + 1);
+      return await executeTokenRefresh(refreshToken, attempt + 1);
     }
 
     throw new Error("Unknown error during token refresh");

--- a/apps/web/src/helpers/authLink.ts
+++ b/apps/web/src/helpers/authLink.ts
@@ -41,7 +41,7 @@ const executeTokenRefresh = async (
     });
 
     if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
+      executeTokenRefresh(refreshToken, attempt + 1);
     }
 
     const data = await response.json();

--- a/apps/web/src/helpers/authLink.ts
+++ b/apps/web/src/helpers/authLink.ts
@@ -41,7 +41,7 @@ const executeTokenRefresh = async (
     });
 
     if (!response.ok) {
-      await executeTokenRefresh(refreshToken, attempt + 1);
+      return await executeTokenRefresh(refreshToken, attempt + 1);
     }
 
     const data = await response.json();

--- a/apps/web/src/helpers/fetcher.ts
+++ b/apps/web/src/helpers/fetcher.ts
@@ -31,8 +31,9 @@ const fetchApi = async <T>(
   });
 
   if (!response.ok) {
-    throw new Error(`API Error: ${response.status}`);
+    throw new Error(`HTTP error! Status: ${response.status}`);
   }
+
   const result = await response.json();
 
   if (result.success) {

--- a/apps/web/src/hooks/prosekit/useEmojis.tsx
+++ b/apps/web/src/hooks/prosekit/useEmojis.tsx
@@ -1,7 +1,6 @@
 import { STATIC_ASSETS_URL } from "@hey/data/constants";
 import type { Emoji } from "@hey/types/misc";
 import { useQuery } from "@tanstack/react-query";
-import axios from "axios";
 import { useMemo } from "react";
 
 const GET_EMOJIS_QUERY_KEY = "getEmojis";
@@ -31,8 +30,8 @@ const useEmojis = ({
     isLoading
   } = useQuery<Emoji[]>({
     queryFn: async () => {
-      const { data } = await axios.get(`${STATIC_ASSETS_URL}/emoji.json`);
-      return data;
+      const response = await fetch(`${STATIC_ASSETS_URL}/emoji.json`);
+      return response.json();
     },
     queryKey: [GET_EMOJIS_QUERY_KEY]
   });

--- a/apps/web/src/hooks/prosekit/useEmojis.tsx
+++ b/apps/web/src/hooks/prosekit/useEmojis.tsx
@@ -31,6 +31,9 @@ const useEmojis = ({
   } = useQuery<Emoji[]>({
     queryFn: async () => {
       const response = await fetch(`${STATIC_ASSETS_URL}/emoji.json`);
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
       return response.json();
     },
     queryKey: [GET_EMOJIS_QUERY_KEY]

--- a/apps/web/vite.config.mjs
+++ b/apps/web/vite.config.mjs
@@ -63,7 +63,6 @@ export default defineConfig({
             "@lens-chain/storage-client",
             "@lens-protocol/metadata",
             "@apollo/client",
-            "axios",
             "zustand",
             "tailwind-merge",
             "zod"

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -11,7 +11,6 @@
     "@hey/data": "workspace:*",
     "@hey/indexer": "workspace:*",
     "@hey/types": "workspace:*",
-    "axios": "^1.8.4",
     "dayjs": "^1.11.13",
     "viem": "^2.26.3"
   },

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@apollo/client": "^3.13.7",
     "@hey/data": "workspace:*",
-    "axios": "^1.8.4",
     "graphql": "^16.10.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       '@prisma/client':
         specifier: ^6.6.0
         version: 6.6.0(prisma@6.6.0(typescript@5.8.3))(typescript@5.8.3)
-      axios:
-        specifier: ^1.8.4
-        version: 1.8.4
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -190,9 +187,6 @@ importers:
       '@uidotdev/usehooks':
         specifier: ^2.4.1
         version: 2.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      axios:
-        specifier: ^1.8.4
-        version: 1.8.4
       browser-image-compression:
         specifier: ^2.0.2
         version: 2.0.2
@@ -373,9 +367,6 @@ importers:
       '@hey/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: ^1.8.4
-        version: 1.8.4
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -401,9 +392,6 @@ importers:
       '@hey/data':
         specifier: workspace:*
         version: link:../data
-      axios:
-        specifier: ^1.8.4
-        version: 1.8.4
       graphql:
         specifier: ^16.10.0
         version: 16.10.0
@@ -3264,9 +3252,6 @@ packages:
   async-mutex@0.2.6:
     resolution: {integrity: sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -3285,9 +3270,6 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
-
-  axios@1.8.4:
-    resolution: {integrity: sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==}
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0:
     resolution: {integrity: sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==}
@@ -3488,10 +3470,6 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -3627,10 +3605,6 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
   dependency-graph@0.11.0:
     resolution: {integrity: sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==}
     engines: {node: '>= 0.6.0'}
@@ -3752,10 +3726,6 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   es-toolkit@1.33.0:
@@ -3897,22 +3867,9 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
-
-  form-data@4.0.2:
-    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
-    engines: {node: '>= 6'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -4654,14 +4611,6 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -5179,9 +5128,6 @@ packages:
 
   proxy-compare@3.0.1:
     resolution: {integrity: sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
@@ -10408,8 +10354,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  asynckit@0.4.0: {}
-
   atomic-sleep@1.0.0: {}
 
   auto-bind@4.0.0: {}
@@ -10427,14 +10371,6 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
-
-  axios@1.8.4:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.2
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
 
@@ -10701,10 +10637,6 @@ snapshots:
 
   colorette@2.0.20: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   comma-separated-tokens@2.0.3: {}
 
   common-tags@1.8.2: {}
@@ -10820,8 +10752,6 @@ snapshots:
       gopd: 1.2.0
 
   defu@6.1.4: {}
-
-  delayed-stream@1.0.0: {}
 
   dependency-graph@0.11.0: {}
 
@@ -10942,13 +10872,6 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
 
   es-toolkit@1.33.0: {}
 
@@ -11117,18 +11040,9 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
-  follow-redirects@1.15.9: {}
-
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
-
-  form-data@4.0.2:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      mime-types: 2.1.35
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -12071,12 +11985,6 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  mime-db@1.52.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
-
   mimic-fn@2.1.0: {}
 
   mini-svg-data-uri@1.4.4: {}
@@ -12613,8 +12521,6 @@ snapshots:
   proxy-compare@2.5.1: {}
 
   proxy-compare@3.0.1: {}
-
-  proxy-from-env@1.1.0: {}
 
   pump@3.0.2:
     dependencies:


### PR DESCRIPTION
This pull request removes the `axios` library and replaces its usage with the native `fetch` API across multiple files. Additionally, it cleans up the `pnpm-lock.yaml` file and several `package.json` files to reflect the removal of `axios`.

### Removal of `axios`:

* [`apps/api/src/routes/oembed/helpers/getMetadata.ts`](diffhunk://#diff-94d6f8325c9dd2fed3a962bb97c64622f3466c563f23535080b1ad12c2f82670L1-R11): Replaced `axios` with `fetch` for fetching metadata.
* [`apps/web/src/components/Composer/Actions/Gif/Categories.tsx`](diffhunk://#diff-84639e6e421a4e9c9e2bf4491f34e0bd98f08fd66c33f2344485c973ffb3b645L5): Replaced `axios` with `fetch` for retrieving Giphy categories. [[1]](diffhunk://#diff-84639e6e421a4e9c9e2bf4491f34e0bd98f08fd66c33f2344485c973ffb3b645L5) [[2]](diffhunk://#diff-84639e6e421a4e9c9e2bf4491f34e0bd98f08fd66c33f2344485c973ffb3b645L17-R20)
* [`apps/web/src/components/Composer/Actions/Gif/Gifs.tsx`](diffhunk://#diff-86e1a5ac3ff6eea89ccf72535ad8f81b2b6ee5db257b26265115fa927db9a782L4): Replaced `axios` with `fetch` for searching Giphy GIFs. [[1]](diffhunk://#diff-86e1a5ac3ff6eea89ccf72535ad8f81b2b6ee5db257b26265115fa927db9a782L4) [[2]](diffhunk://#diff-86e1a5ac3ff6eea89ccf72535ad8f81b2b6ee5db257b26265115fa927db9a782L30-R33)
* [`apps/web/src/helpers/authLink.ts`](diffhunk://#diff-053d1294e68b1b06a968977ec5c78ea28e676600cfb1887cd543805e3c00163cL10): Replaced `axios` with `fetch` for refreshing authentication tokens. [[1]](diffhunk://#diff-053d1294e68b1b06a968977ec5c78ea28e676600cfb1887cd543805e3c00163cL10) [[2]](diffhunk://#diff-053d1294e68b1b06a968977ec5c78ea28e676600cfb1887cd543805e3c00163cL34-R47)
* [`apps/web/src/hooks/prosekit/useEmojis.tsx`](diffhunk://#diff-620c67c2d12e183b2f80f1b9082e4c40922dd9de171d08936db1de79d7e80400L4): Replaced `axios` with `fetch` for fetching emojis. [[1]](diffhunk://#diff-620c67c2d12e183b2f80f1b9082e4c40922dd9de171d08936db1de79d7e80400L4) [[2]](diffhunk://#diff-620c67c2d12e183b2f80f1b9082e4c40922dd9de171d08936db1de79d7e80400L34-R34)

### Package Cleanup:

* [`apps/api/package.json`](diffhunk://#diff-2c40985d6d91eed8ae85ec1c8e754a85984ee32e156a600d2b7a467423d7e338L25): Removed `axios` dependency.
* [`apps/web/package.json`](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L33): Removed `axios` dependency.
* [`packages/helpers/package.json`](diffhunk://#diff-16c47431a4186303697a424ed38d7732842e40407f88b4f23d2fad20f83d18a2L14): Removed `axios` dependency.
* [`packages/indexer/package.json`](diffhunk://#diff-213166961e7fdc9d97fbfaece0dc413fb98d812c4f5ff11e91504ebd63fae4bfL14): Removed `axios` dependency.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL41-L43): Removed all references to `axios` and related dependencies. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL41-L43) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL193-L195) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3267-L3269) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3289-L3291) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3491-L3494) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3630-L3633) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3757-L3760) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3900-L3916) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4657-L4664) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5183-L5185) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10411-L10412) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10431-L10438) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10704-L10707) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10824-L10825) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10946-L10952) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11120-L11132) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12074-L12079) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12617-L12618)

These changes streamline the codebase by removing an external dependency and leveraging the native `fetch` API, which simplifies the code and reduces the bundle size.