### PR TITLE
chore: fixed broken link in Support page

### DIFF
--- a/apps/web/src/components/Pages/Support.tsx
+++ b/apps/web/src/components/Pages/Support.tsx
@@ -18,7 +18,7 @@ const Support = () => {
             <Link to="/terms">Terms of Service</Link>
             <Link to="/privacy">Hey Privacy Policy</Link>
             <Link
-              to="https://www.lens.xyz/legal/lens.xyz-privacy-policy.pdf"
+              to="https://www.lens.xyz/privacy"
               target="_blank"
             >
               Lens Privacy Policy


### PR DESCRIPTION
Hi! I found broken links in [support page](https://hey.xyz/support) - https://lens.xyz/legal/lens.xyz-privacy-policy.pdf
![image](https://github.com/user-attachments/assets/bd0b338d-25a5-4369-9a51-55691a73d656)

Fixed dead link - https://www.lens.xyz/privacy