### PR TITLE
Fix video thumbnail generation

### DIFF
--- a/apps/web/src/helpers/generateVideoThumbnails.ts
+++ b/apps/web/src/helpers/generateVideoThumbnails.ts
@@ -30,7 +30,7 @@ export const generateVideoThumbnails = (
   return new Promise((resolve) => {
     try {
       if (!file.size) {
-        return [];
+        return resolve([]);
       }
       // creating video element to get duration
       const video = document.createElement("video");


### PR DESCRIPTION
## Summary
- fix `generateVideoThumbnails` to resolve promise when the file has zero size

## Testing
- `pnpm test`
- `npx @biomejs/biome format apps/web/src/helpers/generateVideoThumbnails.ts` *(fails: npm error)*

------
https://chatgpt.com/codex/tasks/task_e_683fbbe30e708330ae7103e1a5078710