### PR TITLE
Fix typo in comment

### DIFF
--- a/packages/data/regex.ts
+++ b/packages/data/regex.ts
@@ -3,7 +3,7 @@ import regexLookbehindAvailable from "./utils/regexLookbehindAvailable";
 const RESTRICTED_SYMBOLS = "☑️✓✔✅";
 
 // We only want to match mention when the `@` character is at the start of the
-// line or right after a whilespace.
+// line or right after a whitespace.
 const MATCH_BEHIND = regexLookbehindAvailable ? "(?<=^|\\s)" : "";
 
 const MENTION_NAMESPACE = "\\w+\\/";


### PR DESCRIPTION
## Summary
- fix typo in mention-handling comment

## Testing
- `pnpm test`
- `biome check .` *(fails: biome not found)*
- `pnpm --recursive --parallel run typecheck` *(fails: Prisma client missing)*

------
https://chatgpt.com/codex/tasks/task_e_684058cb54c88330ace4ad02139d8822