### PR TITLE
fix attachment cleanup

### DIFF
--- a/apps/web/src/hooks/useUploadAttachments.tsx
+++ b/apps/web/src/hooks/useUploadAttachments.tsx
@@ -86,6 +86,7 @@ const useUploadAttachments = () => {
 
       const compressedFiles = await compressFiles(files);
       const previewAttachments = createPreviewAttachments(compressedFiles);
+      previewAttachments.forEach(({ id }) => attachmentIds.push(id));
 
       if (compressedFiles.every((file) => validateFileSize(file))) {
         addAttachments(previewAttachments);


### PR DESCRIPTION
## Summary
- track preview attachment ids
- ensure IDs are passed to `removeAttachments` when a failure occurs

## Testing
- `npm run biome:check` *(fails: biome not installed)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684058c738508330bc4ca91564b3c736