### PR TITLE
Fix variable naming in ImageKit helper

### DIFF
--- a/packages/helpers/imageKit.ts
+++ b/packages/helpers/imageKit.ts
@@ -6,8 +6,8 @@ const imageKit = (url: string, name?: string): string => {
   }
 
   if (url.includes(LENS_MEDIA_SNAPSHOT_URL)) {
-    const splitedUrl = url.split("/");
-    const path = splitedUrl[splitedUrl.length - 1];
+    const splitUrl = url.split("/");
+    const path = splitUrl[splitUrl.length - 1];
 
     return name ? `${LENS_MEDIA_SNAPSHOT_URL}/${name}/${path}` : url;
   }


### PR DESCRIPTION
## Summary
- rename `splitedUrl` to `splitUrl`
- update variable references

## Testing
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684059efad848330968a9bc534a5a1cc