### PR TITLE
Refactor useHandleWrongNetwork

### DIFF
--- a/apps/web/src/hooks/useHandleWrongNetwork.tsx
+++ b/apps/web/src/hooks/useHandleWrongNetwork.tsx
@@ -1,29 +1,26 @@
 import { CHAIN } from "@hey/data/constants";
-import { useConnections, useSwitchChain } from "wagmi";
+import { useCallback } from "react";
+import { useAccount, useChainId, useSwitchChain } from "wagmi";
 
 const useHandleWrongNetwork = () => {
-  const activeConnection = useConnections();
+  const { isConnected } = useAccount();
+  const chainId = useChainId();
   const { switchChainAsync } = useSwitchChain();
 
-  const isConnected = () => activeConnection[0] !== undefined;
-  const isWrongNetwork = () => activeConnection[0]?.chainId !== CHAIN.id;
-
-  const handleWrongNetwork = async () => {
-    if (!isConnected()) {
+  return useCallback(async () => {
+    if (!isConnected) {
       console.warn("No active connection found.");
       return;
     }
 
-    if (isWrongNetwork()) {
+    if (chainId !== CHAIN.id) {
       try {
         await switchChainAsync({ chainId: CHAIN.id });
       } catch (error) {
         console.error("Failed to switch chains:", error);
       }
     }
-  };
-
-  return handleWrongNetwork;
+  }, [chainId, isConnected, switchChainAsync]);
 };
 
 export default useHandleWrongNetwork;


### PR DESCRIPTION
## Summary
- refactor `useHandleWrongNetwork` to use `useAccount` and `useChainId`
- memoize the wrong network handler

## Testing
- `pnpm biome:check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684137e288508330b09dd934614222ba