### PR TITLE
Refactor getBlockedMessage helper

### DIFF
--- a/apps/web/src/helpers/getBlockedMessage.ts
+++ b/apps/web/src/helpers/getBlockedMessage.ts
@@ -1,14 +1,17 @@
 import getAccount from "@hey/helpers/getAccount";
 import type { AccountFragment } from "@hey/indexer";
 
-export const getBlockedByMeMessage = (account: AccountFragment): string => {
+const formatMessage = (
+  account: AccountFragment,
+  formatter: (username: string) => string
+): string => {
   const { usernameWithPrefix } = getAccount(account);
 
-  return `You have blocked ${usernameWithPrefix}`;
+  return formatter(usernameWithPrefix);
 };
 
-export const getBlockedMeMessage = (account: AccountFragment): string => {
-  const { usernameWithPrefix } = getAccount(account);
+export const getBlockedByMeMessage = (account: AccountFragment): string =>
+  formatMessage(account, (username) => `You have blocked ${username}`);
 
-  return `${usernameWithPrefix} has blocked you`;
-};
+export const getBlockedMeMessage = (account: AccountFragment): string =>
+  formatMessage(account, (username) => `${username} has blocked you`);


### PR DESCRIPTION
## Summary
- refactor blocked message helper to centralize username formatting

## Testing
- `pnpm biome:check`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68413d9bde4483309ac3734fb41e019c