### PR TITLE
Limit database connections

### DIFF
--- a/apps/api/src/utils/lensPg.ts
+++ b/apps/api/src/utils/lensPg.ts
@@ -19,7 +19,7 @@ type DatabaseQuery = string;
 class Database {
   private _connectionBase: IConnectionParameters = {
     idleTimeoutMillis: 50000,
-    max: 15000,
+    max: 50,
     connectionString: process.env.LENS_DATABASE_URL
   };
 


### PR DESCRIPTION
## Summary
- limit Postgres client pool to 50 connections

## Testing
- `pnpm biome:check`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6843d217a9ec833083c2189a11baeb97