### PR TITLE
Fix interface names

### DIFF
--- a/apps/web/src/components/Groups/FeedType.tsx
+++ b/apps/web/src/components/Groups/FeedType.tsx
@@ -2,12 +2,12 @@ import { Tabs } from "@/components/Shared/UI";
 import { GroupsFeedType } from "@hey/data/enums";
 import type { Dispatch, SetStateAction } from "react";
 
-interface FocusTypeProps {
+interface FeedTypeProps {
   feedType: GroupsFeedType;
   setFeedType: Dispatch<SetStateAction<GroupsFeedType>>;
 }
 
-const FeedType = ({ feedType, setFeedType }: FocusTypeProps) => {
+const FeedType = ({ feedType, setFeedType }: FeedTypeProps) => {
   const tabs = [
     { name: "Managed groups", type: GroupsFeedType.Managed },
     { name: "Your groups", type: GroupsFeedType.Member }

--- a/apps/web/src/components/Settings/Manager/AccountManager/Managers/Permission.tsx
+++ b/apps/web/src/components/Settings/Manager/AccountManager/Managers/Permission.tsx
@@ -10,13 +10,13 @@ import {
 } from "@hey/indexer";
 import { useState } from "react";
 
-interface PermissionsProps {
+interface PermissionProps {
   title: string;
   enabled: boolean;
   manager: AccountManagerFragment;
 }
 
-const Permission = ({ title, enabled, manager }: PermissionsProps) => {
+const Permission = ({ title, enabled, manager }: PermissionProps) => {
   const { currentAccount } = useAccountStore();
   const { setShowAuthModal } = useAuthModalStore();
   const [isSubmitting, setIsSubmitting] = useState(false);


### PR DESCRIPTION
## Summary
- rename `FocusTypeProps` to `FeedTypeProps`
- rename `PermissionsProps` to `PermissionProps`

## Testing
- `pnpm biome:check`
- `pnpm typecheck` *(fails: packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843d2d362d483309c154a4e73f69a04