### PR TITLE
Improve Apollo error typing

### DIFF
--- a/apps/web/src/components/Settings/Funds/Unwrap.tsx
+++ b/apps/web/src/components/Settings/Funds/Unwrap.tsx
@@ -4,6 +4,7 @@ import usePollTransactionStatus from "@/hooks/usePollTransactionStatus";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import { NATIVE_TOKEN_SYMBOL } from "@hey/data/constants";
 import { useUnwrapTokensMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -28,7 +29,7 @@ const Unwrap = ({ value, refetch }: UnwrapProps) => {
     });
   };
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Settings/Funds/Withdraw.tsx
+++ b/apps/web/src/components/Settings/Funds/Withdraw.tsx
@@ -3,6 +3,7 @@ import errorToast from "@/helpers/errorToast";
 import usePollTransactionStatus from "@/hooks/usePollTransactionStatus";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import { useWithdrawMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 import type { Address } from "viem";
@@ -29,7 +30,7 @@ const Withdraw = ({ currency, value, refetch }: WithdrawProps) => {
     });
   };
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Settings/Funds/Wrap.tsx
+++ b/apps/web/src/components/Settings/Funds/Wrap.tsx
@@ -4,6 +4,7 @@ import usePollTransactionStatus from "@/hooks/usePollTransactionStatus";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import { WRAPPED_NATIVE_TOKEN_SYMBOL } from "@hey/data/constants";
 import { useWrapTokensMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -28,7 +29,7 @@ const Wrap = ({ value, refetch }: WrapProps) => {
     });
   };
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Settings/Manager/AccountManager/Managers/Permission.tsx
+++ b/apps/web/src/components/Settings/Manager/AccountManager/Managers/Permission.tsx
@@ -8,6 +8,7 @@ import {
   type AccountManagerFragment,
   useUpdateAccountManagerMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 
 interface PermissionsProps {
@@ -41,7 +42,7 @@ const Permission = ({ title, enabled, manager }: PermissionsProps) => {
     setIsSubmitting(false);
   };
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/Account/Follow.tsx
+++ b/apps/web/src/components/Shared/Account/Follow.tsx
@@ -5,6 +5,7 @@ import { useAuthModalStore } from "@/store/non-persisted/modal/useAuthModalStore
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { useApolloClient } from "@apollo/client";
 import { type AccountFragment, useFollowMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 
 interface FollowProps {
@@ -45,7 +46,7 @@ const Follow = ({
     onFollow?.();
   };
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/Account/TopUp/Transfer.tsx
+++ b/apps/web/src/components/Shared/Account/TopUp/Transfer.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/store/non-persisted/modal/useFundModalStore";
 import { NATIVE_TOKEN_SYMBOL } from "@hey/data/constants";
 import { useDepositMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { type ChangeEvent, type RefObject, useRef, useState } from "react";
 import { toast } from "sonner";
 import { formatUnits } from "viem";
@@ -46,7 +47,7 @@ const Transfer = ({ token }: TransferProps) => {
     });
   };
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/Account/Unfollow.tsx
+++ b/apps/web/src/components/Shared/Account/Unfollow.tsx
@@ -5,6 +5,7 @@ import { useAuthModalStore } from "@/store/non-persisted/modal/useAuthModalStore
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { useApolloClient } from "@apollo/client";
 import { type AccountFragment, useUnfollowMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 
 interface UnfollowProps {
@@ -42,7 +43,7 @@ const Unfollow = ({
     setIsSubmitting(false);
   };
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/Audio/CoverImage.tsx
+++ b/apps/web/src/components/Shared/Audio/CoverImage.tsx
@@ -6,6 +6,7 @@ import { PhotoIcon } from "@heroicons/react/24/outline";
 import { TRANSFORMS } from "@hey/data/constants";
 import imageKit from "@hey/helpers/imageKit";
 import sanitizeDStorageUrl from "@hey/helpers/sanitizeDStorageUrl";
+import type { ApolloClientError } from "@hey/types/errors";
 import type { ChangeEvent, Ref } from "react";
 import { useState } from "react";
 
@@ -24,7 +25,7 @@ const CoverImage = ({
 }: CoverImageProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/Auth/Signup/Success.tsx
+++ b/apps/web/src/components/Shared/Auth/Signup/Success.tsx
@@ -4,13 +4,14 @@ import { signIn } from "@/store/persisted/useAuthStore";
 import { STATIC_IMAGES_URL } from "@hey/data/constants";
 import { Errors } from "@hey/data/errors";
 import { useSwitchAccountMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useEffect } from "react";
 import { useSignupStore } from ".";
 
 const Success = () => {
   const { accountAddress, onboardingToken } = useSignupStore();
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     errorToast(error);
   };
 

--- a/apps/web/src/components/Shared/AvatarUpload.tsx
+++ b/apps/web/src/components/Shared/AvatarUpload.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_AVATAR, TRANSFORMS } from "@hey/data/constants";
 import { Errors } from "@hey/data/errors";
 import imageKit from "@hey/helpers/imageKit";
 import sanitizeDStorageUrl from "@hey/helpers/sanitizeDStorageUrl";
+import type { ApolloClientError } from "@hey/types/errors";
 import type { ChangeEvent, SyntheticEvent } from "react";
 import { useState } from "react";
 import Cropper, { type Area } from "react-easy-crop";
@@ -29,7 +30,7 @@ const AvatarUpload = ({ src, setSrc, isSmall = false }: AvatarUploadProps) => {
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/CoverUpload.tsx
+++ b/apps/web/src/components/Shared/CoverUpload.tsx
@@ -8,6 +8,7 @@ import { STATIC_IMAGES_URL, TRANSFORMS } from "@hey/data/constants";
 import { Errors } from "@hey/data/errors";
 import imageKit from "@hey/helpers/imageKit";
 import sanitizeDStorageUrl from "@hey/helpers/sanitizeDStorageUrl";
+import type { ApolloClientError } from "@hey/types/errors";
 import type { ChangeEvent, SyntheticEvent } from "react";
 import { useState } from "react";
 import Cropper, { type Area } from "react-easy-crop";
@@ -28,7 +29,7 @@ const CoverUpload = ({ src, setSrc }: CoverUploadProps) => {
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/Group/CancelGroupMembershipRequest.tsx
+++ b/apps/web/src/components/Shared/Group/CancelGroupMembershipRequest.tsx
@@ -6,6 +6,7 @@ import {
   type GroupFragment,
   useCancelGroupMembershipRequestMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -39,7 +40,7 @@ const CancelGroupMembershipRequest = ({
     toast.success("Request cancelled");
   };
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/Group/Join.tsx
+++ b/apps/web/src/components/Shared/Group/Join.tsx
@@ -7,6 +7,7 @@ import {
   useJoinGroupMutation,
   useRequestGroupMembershipMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -51,7 +52,7 @@ const Join = ({
     );
   };
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/Group/Leave.tsx
+++ b/apps/web/src/components/Shared/Group/Leave.tsx
@@ -3,6 +3,7 @@ import errorToast from "@/helpers/errorToast";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import { useApolloClient } from "@apollo/client";
 import { type GroupFragment, useLeaveGroupMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -33,7 +34,7 @@ const Leave = ({ group, small }: LeaveProps) => {
     toast.success("Left group");
   };
 
-  const onError = (error: any) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/hooks/useTransactionLifecycle.tsx
+++ b/apps/web/src/hooks/useTransactionLifecycle.tsx
@@ -1,6 +1,7 @@
 import { Errors } from "@hey/data/errors";
 import selfFundedTransactionData from "@hey/helpers/selfFundedTransactionData";
 import sponsoredTransactionData from "@hey/helpers/sponsoredTransactionData";
+import type { ApolloClientError } from "@hey/types/errors";
 import { sendEip712Transaction, sendTransaction } from "viem/zksync";
 import { useWalletClient } from "wagmi";
 import useHandleWrongNetwork from "./useHandleWrongNetwork";
@@ -44,7 +45,7 @@ const useTransactionLifecycle = () => {
   }: {
     transactionData: any;
     onCompleted: (hash: string) => void;
-    onError: (error: any) => void;
+    onError: (error: ApolloClientError) => void;
   }) => {
     try {
       switch (transactionData.__typename) {

--- a/packages/types/errors.d.ts
+++ b/packages/types/errors.d.ts
@@ -1,0 +1,9 @@
+import type { ApolloError } from "@apollo/client";
+import type { ServerParseError } from "@apollo/client/link/http";
+import type { ServerError } from "@apollo/client/link/utils";
+
+export type ApolloClientError =
+  | ApolloError
+  | ServerError
+  | ServerParseError
+  | Error;


### PR DESCRIPTION
## Summary
- define `ApolloClientError` union for common Apollo errors
- use `ApolloClientError` in transaction lifecycle hook
- apply better error typing across fund and modal components

## Testing
- `pnpm biome:check`
- `pnpm --recursive --parallel run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6843d3d828608330b8ee8407c76a86e0