### PR TITLE
Refactor tipping and personalize logic

### DIFF
--- a/apps/web/src/hooks/useSplitConfig.tsx
+++ b/apps/web/src/hooks/useSplitConfig.tsx
@@ -1,0 +1,114 @@
+import splitNumber from "@/helpers/splitNumber";
+import { useCollectActionStore } from "@/store/non-persisted/post/useCollectActionStore";
+import { useAccountStore } from "@/store/persisted/useAccountStore";
+import type { CollectActionType } from "@hey/types/hey";
+import { useCallback, useState } from "react";
+
+const useSplitConfig = (setCollectType: (data: CollectActionType) => void) => {
+  const { currentAccount } = useAccountStore();
+  const { collectAction } = useCollectActionStore((state) => state);
+
+  const currentAddress = currentAccount?.address || "";
+  const recipients = collectAction.payToCollect?.recipients || [];
+  const [isToggleOn, setIsToggleOn] = useState(
+    recipients.length > 1 ||
+      (recipients.length === 1 && recipients[0].address !== currentAddress)
+  );
+  const splitTotal = recipients.reduce((acc, curr) => acc + curr.percent, 0);
+
+  const handleSplitEvenly = useCallback(() => {
+    const equalSplits = splitNumber(100, recipients.length);
+    const splits = recipients.map((recipient, i) => ({
+      address: recipient.address,
+      percent: equalSplits[i]
+    }));
+    if (!collectAction.payToCollect) return;
+    setCollectType({
+      payToCollect: {
+        ...collectAction.payToCollect,
+        recipients: [...splits]
+      }
+    });
+  }, [recipients, collectAction.payToCollect, setCollectType]);
+
+  const onChangeRecipientOrPercent = useCallback(
+    (index: number, value: string, type: "address" | "percent") => {
+      const getRecipients = (val: string) =>
+        recipients.map((recipient, i) => {
+          if (i === index) {
+            return {
+              ...recipient,
+              [type]: type === "address" ? val : Number.parseInt(val)
+            };
+          }
+          return recipient;
+        });
+
+      if (!collectAction.payToCollect) return;
+      setCollectType({
+        payToCollect: {
+          ...collectAction.payToCollect,
+          recipients: getRecipients(value)
+        }
+      });
+    },
+    [recipients, collectAction.payToCollect, setCollectType]
+  );
+
+  const updateRecipient = useCallback(
+    (index: number, value: string) => {
+      onChangeRecipientOrPercent(index, value, "address");
+    },
+    [onChangeRecipientOrPercent]
+  );
+
+  const handleRemoveRecipient = useCallback(
+    (index: number) => {
+      const updatedRecipients = recipients.filter((_, i) => i !== index);
+      if (updatedRecipients.length) {
+        if (!collectAction.payToCollect) return;
+        setCollectType({
+          payToCollect: {
+            ...collectAction.payToCollect,
+            recipients: updatedRecipients
+          }
+        });
+      } else {
+        if (!collectAction.payToCollect) return;
+        setCollectType({
+          payToCollect: {
+            ...collectAction.payToCollect,
+            recipients: [{ address: currentAddress, percent: 100 }]
+          }
+        });
+        setIsToggleOn(false);
+      }
+    },
+    [recipients, collectAction.payToCollect, setCollectType, currentAddress]
+  );
+
+  const toggleSplit = useCallback(() => {
+    if (!collectAction.payToCollect) return;
+    setCollectType({
+      payToCollect: {
+        ...collectAction.payToCollect,
+        recipients: [{ address: currentAddress, percent: 100 }]
+      }
+    });
+    setIsToggleOn(!isToggleOn);
+  }, [collectAction.payToCollect, setCollectType, isToggleOn, currentAddress]);
+
+  return {
+    recipients,
+    isToggleOn,
+    setIsToggleOn,
+    splitTotal,
+    handleSplitEvenly,
+    onChangeRecipientOrPercent,
+    updateRecipient,
+    handleRemoveRecipient,
+    toggleSplit
+  };
+};
+
+export default useSplitConfig;

--- a/apps/web/src/hooks/useTip.tsx
+++ b/apps/web/src/hooks/useTip.tsx
@@ -1,0 +1,123 @@
+import errorToast from "@/helpers/errorToast";
+import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
+import { useAccountStore } from "@/store/persisted/useAccountStore";
+import { useApolloClient } from "@apollo/client";
+import { HEY_TREASURY, NATIVE_TOKEN_SYMBOL } from "@hey/data/constants";
+import {
+  type AccountFragment,
+  type PostFragment,
+  type TippingAmountInput,
+  useExecuteAccountActionMutation,
+  useExecutePostActionMutation
+} from "@hey/indexer";
+import React, { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+interface UseTipProps {
+  closePopover: () => void;
+  post?: PostFragment;
+  account?: AccountFragment;
+}
+
+const useTip = ({ closePopover, post, account }: UseTipProps) => {
+  const { currentAccount } = useAccountStore();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const handleTransactionLifecycle = useTransactionLifecycle();
+  const { cache } = useApolloClient();
+
+  const updateCache = useCallback(() => {
+    if (post?.operations) {
+      cache.modify({
+        fields: { hasTipped: () => true },
+        id: cache.identify(post.operations)
+      });
+      cache.modify({
+        fields: {
+          stats: (existingData) => ({
+            ...existingData,
+            tips: existingData.tips + 1
+          })
+        },
+        id: cache.identify(post)
+      });
+    }
+  }, [cache, post]);
+
+  const onCompleted = useCallback(
+    (amount: number) => {
+      setIsSubmitting(false);
+      closePopover();
+      updateCache();
+      toast.success(`Tipped ${amount} ${NATIVE_TOKEN_SYMBOL}`);
+    },
+    [closePopover, updateCache]
+  );
+
+  const onError = useCallback((error: Error) => {
+    setIsSubmitting(false);
+    errorToast(error);
+  }, []);
+
+  const [executePostAction] = useExecutePostActionMutation({
+    onCompleted: async ({ executePostAction }) => {
+      if (executePostAction.__typename === "ExecutePostActionResponse") {
+        return onCompleted(lastAmountRef.current);
+      }
+
+      return await handleTransactionLifecycle({
+        transactionData: executePostAction,
+        onCompleted: () => onCompleted(lastAmountRef.current),
+        onError
+      });
+    },
+    onError
+  });
+
+  const [executeAccountAction] = useExecuteAccountActionMutation({
+    onCompleted: async ({ executeAccountAction }) => {
+      if (executeAccountAction.__typename === "ExecuteAccountActionResponse") {
+        return onCompleted(lastAmountRef.current);
+      }
+
+      return await handleTransactionLifecycle({
+        transactionData: executeAccountAction,
+        onCompleted: () => onCompleted(lastAmountRef.current),
+        onError
+      });
+    },
+    onError
+  });
+
+  const lastAmountRef = React.useRef(0);
+
+  const tip = useCallback(
+    async (amount: number) => {
+      if (!currentAccount) return;
+      setIsSubmitting(true);
+      lastAmountRef.current = amount;
+      const tipping: TippingAmountInput = {
+        referrals: [{ address: HEY_TREASURY, percent: 11 }],
+        native: amount.toString()
+      };
+
+      if (post) {
+        return executePostAction({
+          variables: { request: { post: post.id, action: { tipping } } }
+        });
+      }
+
+      if (account) {
+        return executeAccountAction({
+          variables: {
+            request: { account: account.address, action: { tipping } }
+          }
+        });
+      }
+    },
+    [currentAccount, executePostAction, executeAccountAction, post, account]
+  );
+
+  return { tip, isSubmitting };
+};
+
+export default useTip;

--- a/apps/web/src/hooks/useUpdateAccountMetadata.tsx
+++ b/apps/web/src/hooks/useUpdateAccountMetadata.tsx
@@ -1,0 +1,136 @@
+import errorToast from "@/helpers/errorToast";
+import trimify from "@/helpers/trimify";
+import uploadMetadata from "@/helpers/uploadMetadata";
+import usePollTransactionStatus from "@/hooks/usePollTransactionStatus";
+import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
+import { useAccountStore } from "@/store/persisted/useAccountStore";
+import { Errors } from "@hey/data/errors";
+import { useMeLazyQuery, useSetAccountMetadataMutation } from "@hey/indexer";
+import type {
+  AccountOptions,
+  MetadataAttribute
+} from "@lens-protocol/metadata";
+import {
+  MetadataAttributeType,
+  account as accountMetadata
+} from "@lens-protocol/metadata";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+const useUpdateAccountMetadata = () => {
+  const { currentAccount, setCurrentAccount } = useAccountStore();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const handleTransactionLifecycle = useTransactionLifecycle();
+  const pollTransactionStatus = usePollTransactionStatus();
+  const [getCurrentAccountDetails] = useMeLazyQuery({
+    fetchPolicy: "no-cache"
+  });
+
+  const onCompleted = useCallback(
+    (hash: string) => {
+      pollTransactionStatus(hash, async () => {
+        const accountData = await getCurrentAccountDetails();
+        setCurrentAccount(accountData?.data?.me.loggedInAs.account);
+        setIsSubmitting(false);
+        toast.success("Account updated");
+      });
+    },
+    [pollTransactionStatus, getCurrentAccountDetails, setCurrentAccount]
+  );
+
+  const onError = useCallback((error: Error) => {
+    setIsSubmitting(false);
+    errorToast(error);
+  }, []);
+
+  const [setAccountMetadata] = useSetAccountMetadataMutation({
+    onCompleted: async ({ setAccountMetadata }) => {
+      if (setAccountMetadata.__typename === "SetAccountMetadataResponse") {
+        return onCompleted(setAccountMetadata.hash);
+      }
+
+      return await handleTransactionLifecycle({
+        transactionData: setAccountMetadata,
+        onCompleted,
+        onError
+      });
+    },
+    onError
+  });
+
+  const updateAccount = useCallback(
+    async (
+      data: {
+        bio: string;
+        location: string;
+        name: string;
+        website: string;
+        x: string;
+      },
+      pfpUrl: string | undefined,
+      coverUrl: string | undefined
+    ) => {
+      if (!currentAccount) {
+        toast.error(Errors.SignWallet);
+        return;
+      }
+
+      setIsSubmitting(true);
+      const otherAttributes =
+        currentAccount.metadata?.attributes
+          ?.filter(
+            (attr) =>
+              !["app", "location", "timestamp", "website", "x"].includes(
+                attr.key
+              )
+          )
+          .map(({ key, type, value }) => ({
+            key,
+            type: MetadataAttributeType[type] as any,
+            value
+          })) || [];
+
+      const preparedAccountMetadata: AccountOptions = {
+        ...(data.name && { name: data.name }),
+        ...(data.bio && { bio: data.bio }),
+        attributes: [
+          ...(otherAttributes as MetadataAttribute[]),
+          {
+            key: "location",
+            type: MetadataAttributeType.STRING,
+            value: data.location
+          },
+          {
+            key: "website",
+            type: MetadataAttributeType.STRING,
+            value: data.website
+          },
+          { key: "x", type: MetadataAttributeType.STRING, value: data.x },
+          {
+            key: "timestamp",
+            type: MetadataAttributeType.STRING,
+            value: new Date().toISOString()
+          }
+        ],
+        coverPicture: coverUrl || undefined,
+        picture: pfpUrl || undefined
+      };
+
+      preparedAccountMetadata.attributes =
+        preparedAccountMetadata.attributes?.filter((m) => {
+          return m.key !== "" && Boolean(trimify(m.value));
+        });
+
+      const metadataUri = await uploadMetadata(
+        accountMetadata(preparedAccountMetadata)
+      );
+
+      await setAccountMetadata({ variables: { request: { metadataUri } } });
+    },
+    [currentAccount, setAccountMetadata]
+  );
+
+  return { updateAccount, isSubmitting };
+};
+
+export default useUpdateAccountMetadata;

--- a/apps/web/src/hooks/useUpdateGroupMetadata.tsx
+++ b/apps/web/src/hooks/useUpdateGroupMetadata.tsx
@@ -1,0 +1,73 @@
+import errorToast from "@/helpers/errorToast";
+import uploadMetadata from "@/helpers/uploadMetadata";
+import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
+import { useAccountStore } from "@/store/persisted/useAccountStore";
+import { Errors } from "@hey/data/errors";
+import { type GroupFragment, useSetGroupMetadataMutation } from "@hey/indexer";
+import { group as groupMetadata } from "@lens-protocol/metadata";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+const useUpdateGroupMetadata = (group: GroupFragment) => {
+  const { currentAccount } = useAccountStore();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const handleTransactionLifecycle = useTransactionLifecycle();
+
+  const onCompleted = useCallback(() => {
+    setIsSubmitting(false);
+    toast.success("Group updated");
+  }, []);
+
+  const onError = useCallback((error: Error) => {
+    setIsSubmitting(false);
+    errorToast(error);
+  }, []);
+
+  const [setGroupMetadata] = useSetGroupMetadataMutation({
+    onCompleted: async ({ setGroupMetadata }) => {
+      if (setGroupMetadata.__typename === "SetGroupMetadataResponse") {
+        return onCompleted();
+      }
+
+      return await handleTransactionLifecycle({
+        transactionData: setGroupMetadata,
+        onCompleted,
+        onError
+      });
+    },
+    onError
+  });
+
+  const updateGroup = useCallback(
+    async (
+      data: { name: string; description: string },
+      pfpUrl: string | undefined,
+      coverUrl: string | undefined
+    ) => {
+      if (!currentAccount) {
+        toast.error(Errors.SignWallet);
+        return;
+      }
+
+      setIsSubmitting(true);
+
+      const metadataUri = await uploadMetadata(
+        groupMetadata({
+          name: data.name,
+          description: data.description,
+          icon: pfpUrl || undefined,
+          coverPicture: coverUrl || undefined
+        })
+      );
+
+      await setGroupMetadata({
+        variables: { request: { group: group.address, metadataUri } }
+      });
+    },
+    [currentAccount, setGroupMetadata, group.address]
+  );
+
+  return { updateGroup, isSubmitting };
+};
+
+export default useUpdateGroupMetadata;


### PR DESCRIPTION
## Summary
- move account personalize mutation logic into `useUpdateAccountMetadata`
- move group personalize mutation logic into `useUpdateGroupMetadata`
- extract tipping transactions into `useTip`
- create `useSplitConfig` for split recipients handling
- update UI components to use new hooks

## Testing
- `pnpm biome:check`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6843d3cd4b00833085fe3f3eb727617a