### PR TITLE
Add helper tests and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --recursive --parallel run test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,11 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm --recursive --parallel run test
+      - run: pnpm install
+      - run: pnpm test

--- a/packages/helpers/formatAddress.test.ts
+++ b/packages/helpers/formatAddress.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import formatAddress from "./formatAddress";
+
+const address = "0x1234567890abcdef1234567890abcdef12345678";
+
+describe("formatAddress", () => {
+  it("returns empty string for null", () => {
+    expect(formatAddress(null)).toBe("");
+  });
+
+  it("formats valid address", () => {
+    expect(formatAddress(address)).toBe("0x12…5678");
+  });
+
+  it("uses custom slice size", () => {
+    expect(formatAddress(address, 6)).toBe("0x1234…345678");
+  });
+
+  it("lowercases invalid address", () => {
+    expect(formatAddress("NOTanADDRESS")).toBe("notanaddress");
+  });
+});

--- a/packages/helpers/getAccount.test.ts
+++ b/packages/helpers/getAccount.test.ts
@@ -1,0 +1,61 @@
+import { LENS_NAMESPACE, NULL_ADDRESS } from "@hey/data/constants";
+import { describe, expect, it } from "vitest";
+import formatAddress from "./formatAddress";
+import getAccount from "./getAccount";
+
+const address = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
+
+// minimal account type
+interface Account {
+  owner: string;
+  address: string;
+  metadata?: { name?: string | null } | null;
+  username?: { value: string; localName: string } | null;
+}
+
+describe("getAccount", () => {
+  it("returns unknown account when undefined", () => {
+    expect(getAccount()).toEqual({
+      name: "...",
+      link: "",
+      username: "...",
+      usernameWithPrefix: "..."
+    });
+  });
+
+  it("returns deleted account", () => {
+    const account: Account = { owner: NULL_ADDRESS, address };
+    expect(getAccount(account as any)).toEqual({
+      name: "Deleted Account",
+      link: "",
+      username: "deleted",
+      usernameWithPrefix: "@deleted"
+    });
+  });
+
+  it("handles lens username and sanitizes name", () => {
+    const account: Account = {
+      owner: "0x1",
+      address,
+      metadata: { name: "Alice✓" },
+      username: { value: `${LENS_NAMESPACE}alice`, localName: "alice" }
+    };
+    expect(getAccount(account as any)).toEqual({
+      name: "Alice",
+      link: "/u/alice",
+      username: "alice",
+      usernameWithPrefix: "@alice"
+    });
+  });
+
+  it("uses address when username missing", () => {
+    const account: Account = { owner: "0x1", address };
+    const formatted = formatAddress(address);
+    expect(getAccount(account as any)).toEqual({
+      name: formatted,
+      link: `/account/${address}`,
+      username: formatted,
+      usernameWithPrefix: `#${formatted}`
+    });
+  });
+});

--- a/packages/helpers/getAttachmentsData.test.ts
+++ b/packages/helpers/getAttachmentsData.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import getAttachmentsData from "./getAttachmentsData";
+import sanitizeDStorageUrl from "./sanitizeDStorageUrl";
+
+const ipfs = `Qm${"a".repeat(44)}`;
+const sanitized = sanitizeDStorageUrl(ipfs);
+
+describe("getAttachmentsData", () => {
+  it("returns empty array when undefined", () => {
+    expect(getAttachmentsData()).toEqual([]);
+  });
+
+  it("maps media types", () => {
+    const attachments = [
+      { __typename: "MediaImage", item: ipfs },
+      { __typename: "MediaVideo", item: ipfs, cover: ipfs },
+      { __typename: "MediaAudio", item: ipfs, cover: ipfs, artist: "a" }
+    ];
+    expect(getAttachmentsData(attachments as any)).toEqual([
+      { type: "Image", uri: sanitized },
+      { type: "Video", uri: sanitized, coverUri: sanitized },
+      { type: "Audio", uri: sanitized, coverUri: sanitized, artist: "a" }
+    ]);
+  });
+});

--- a/packages/helpers/getAvatar.test.ts
+++ b/packages/helpers/getAvatar.test.ts
@@ -1,0 +1,31 @@
+import {
+  DEFAULT_AVATAR,
+  LENS_MEDIA_SNAPSHOT_URL,
+  TRANSFORMS
+} from "@hey/data/constants";
+import { describe, expect, it } from "vitest";
+import getAvatar from "./getAvatar";
+
+const ipfs = "ipfs://avatarHash";
+
+describe("getAvatar", () => {
+  it("returns default when entity missing", () => {
+    expect(getAvatar(undefined as any)).toBe(DEFAULT_AVATAR);
+  });
+
+  it("sanitizes ipfs avatar", () => {
+    const avatar = getAvatar({ metadata: { picture: ipfs } });
+    expect(avatar).toContain("gw.ipfs-lens.dev/ipfs/avatarHash");
+  });
+
+  it("applies imageKit transform", () => {
+    const url = `${LENS_MEDIA_SNAPSHOT_URL}/path/file.png`;
+    const result = getAvatar(
+      { metadata: { picture: url } },
+      TRANSFORMS.AVATAR_TINY
+    );
+    expect(result).toBe(
+      `${LENS_MEDIA_SNAPSHOT_URL}/${TRANSFORMS.AVATAR_TINY}/file.png`
+    );
+  });
+});

--- a/packages/helpers/getPostData.test.ts
+++ b/packages/helpers/getPostData.test.ts
@@ -1,0 +1,52 @@
+import { PLACEHOLDER_IMAGE } from "@hey/data/constants";
+import { describe, expect, it } from "vitest";
+import getPostData from "./getPostData";
+import sanitizeDStorageUrl from "./sanitizeDStorageUrl";
+
+const ipfs = `Qm${"a".repeat(44)}`;
+const sanitized = sanitizeDStorageUrl(ipfs);
+
+describe("getPostData", () => {
+  it("handles text-only metadata", () => {
+    const meta = { __typename: "TextOnlyMetadata", content: "hi" } as any;
+    expect(getPostData(meta)).toEqual({ content: "hi" });
+  });
+
+  it("handles image metadata", () => {
+    const meta = {
+      __typename: "ImageMetadata",
+      content: "img",
+      image: { item: ipfs },
+      attachments: [{ __typename: "MediaImage", item: ipfs }]
+    } as any;
+    expect(getPostData(meta)).toEqual({
+      asset: { type: "Image", uri: sanitized },
+      attachments: [{ type: "Image", uri: sanitized }],
+      content: "img"
+    });
+  });
+
+  it("handles audio metadata with placeholder", () => {
+    const meta = {
+      __typename: "AudioMetadata",
+      content: "audio",
+      title: undefined,
+      audio: { item: ipfs, cover: undefined, artist: undefined },
+      attachments: []
+    } as any;
+    expect(getPostData(meta)).toEqual({
+      asset: {
+        artist: undefined,
+        cover: sanitizeDStorageUrl(PLACEHOLDER_IMAGE),
+        title: "Untitled",
+        type: "Audio",
+        uri: ipfs
+      },
+      content: "audio"
+    });
+  });
+
+  it("returns null for unknown type", () => {
+    expect(getPostData({ __typename: "Unknown" } as any)).toBeNull();
+  });
+});

--- a/packages/helpers/imageKit.test.ts
+++ b/packages/helpers/imageKit.test.ts
@@ -1,0 +1,22 @@
+import { LENS_MEDIA_SNAPSHOT_URL } from "@hey/data/constants";
+import { describe, expect, it } from "vitest";
+import imageKit from "./imageKit";
+
+describe("imageKit", () => {
+  it("returns empty string for empty url", () => {
+    expect(imageKit("")).toBe("");
+  });
+
+  it("passes through non snapshot url", () => {
+    expect(imageKit("https://example.com/a.png")).toBe(
+      "https://example.com/a.png"
+    );
+  });
+
+  it("applies transform for snapshot url", () => {
+    const url = `${LENS_MEDIA_SNAPSHOT_URL}/path/file.jpg`;
+    expect(imageKit(url, "tr:w-100")).toBe(
+      `${LENS_MEDIA_SNAPSHOT_URL}/tr:w-100/file.jpg`
+    );
+  });
+});

--- a/packages/helpers/isAccountDeleted.test.ts
+++ b/packages/helpers/isAccountDeleted.test.ts
@@ -1,0 +1,12 @@
+import { NULL_ADDRESS } from "@hey/data/constants";
+import { describe, expect, it } from "vitest";
+import isAccountDeleted from "./isAccountDeleted";
+
+describe("isAccountDeleted", () => {
+  it("returns true when owner is null address", () => {
+    expect(isAccountDeleted({ owner: NULL_ADDRESS } as any)).toBe(true);
+  });
+  it("returns false otherwise", () => {
+    expect(isAccountDeleted({ owner: "0x1" } as any)).toBe(false);
+  });
+});

--- a/packages/helpers/parseJwt.test.ts
+++ b/packages/helpers/parseJwt.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import parseJwt from "./parseJwt";
+
+describe("parseJwt", () => {
+  it("parses valid token", () => {
+    const payload = { sub: "1", exp: 2, sid: "abc", act: { sub: "1" } };
+    const encoded = Buffer.from(JSON.stringify(payload)).toString("base64");
+    const token = `a.${encoded}.b`;
+    expect(parseJwt(token)).toEqual(payload);
+  });
+
+  it("returns defaults on invalid token", () => {
+    expect(parseJwt("invalid")).toEqual({
+      sub: "",
+      exp: 0,
+      sid: "",
+      act: { sub: "" }
+    });
+  });
+});

--- a/packages/helpers/postHelpers.test.ts
+++ b/packages/helpers/postHelpers.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { isRepost } from "./postHelpers";
+
+describe("isRepost", () => {
+  it("detects repost", () => {
+    expect(isRepost({ __typename: "Repost" } as any)).toBe(true);
+  });
+  it("returns false otherwise", () => {
+    expect(isRepost({ __typename: "Post" } as any)).toBe(false);
+  });
+});

--- a/packages/helpers/sanitizeDStorageUrl.test.ts
+++ b/packages/helpers/sanitizeDStorageUrl.test.ts
@@ -1,0 +1,32 @@
+import { IPFS_GATEWAY, STORAGE_NODE_URL } from "@hey/data/constants";
+import { describe, expect, it } from "vitest";
+import sanitizeDStorageUrl from "./sanitizeDStorageUrl";
+
+describe("sanitizeDStorageUrl", () => {
+  const hash = `Qm${"a".repeat(44)}`;
+  it("handles undefined", () => {
+    expect(sanitizeDStorageUrl()).toBe("");
+  });
+
+  it("prepends gateway for bare hash", () => {
+    expect(sanitizeDStorageUrl(hash)).toBe(`${IPFS_GATEWAY}/${hash}`);
+  });
+
+  it("converts ipfs://", () => {
+    expect(sanitizeDStorageUrl(`ipfs://${hash}`)).toBe(
+      `${IPFS_GATEWAY}/${hash}`
+    );
+  });
+
+  it("converts lens://", () => {
+    expect(sanitizeDStorageUrl(`lens://${hash}`)).toBe(
+      `${STORAGE_NODE_URL}/${hash}`
+    );
+  });
+
+  it("converts ar://", () => {
+    expect(sanitizeDStorageUrl(`ar://${hash}`)).toBe(
+      `https://gateway.arweave.net/${hash}`
+    );
+  });
+});

--- a/packages/helpers/selfFundedTransactionData.test.ts
+++ b/packages/helpers/selfFundedTransactionData.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import selfFundedTransactionData from "./selfFundedTransactionData";
+
+describe("selfFundedTransactionData", () => {
+  it("converts fields to bigint", () => {
+    const raw = {
+      data: "0x",
+      gasLimit: 1,
+      maxFeePerGas: 2,
+      maxPriorityFeePerGas: 3,
+      nonce: 4,
+      to: "0x1",
+      value: 5
+    } as any;
+    expect(selfFundedTransactionData(raw)).toEqual({
+      data: "0x",
+      gas: 1n,
+      maxFeePerGas: 2n,
+      maxPriorityFeePerGas: 3n,
+      nonce: 4,
+      to: "0x1",
+      value: 5n
+    });
+  });
+});

--- a/packages/helpers/sponsoredTransactionData.test.ts
+++ b/packages/helpers/sponsoredTransactionData.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import sponsoredTransactionData from "./sponsoredTransactionData";
+
+describe("sponsoredTransactionData", () => {
+  it("converts fields and includes paymaster", () => {
+    const raw = {
+      data: "0x",
+      gasLimit: 1,
+      maxFeePerGas: 2,
+      maxPriorityFeePerGas: 3,
+      nonce: 4,
+      to: "0x1",
+      value: 5,
+      customData: {
+        paymasterParams: { paymaster: "p", paymasterInput: "i" }
+      }
+    } as any;
+    expect(sponsoredTransactionData(raw)).toEqual({
+      data: "0x",
+      gas: 1n,
+      maxFeePerGas: 2n,
+      maxPriorityFeePerGas: 3n,
+      nonce: 4,
+      paymaster: "p",
+      paymasterInput: "i",
+      to: "0x1",
+      value: 5n
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest coverage for helper utilities
- run tests in a new CI workflow

## Testing
- `pnpm --recursive --parallel run test`

------
https://chatgpt.com/codex/tasks/task_e_6843d5de73288330b242b9b08fb1ed79