### PR TITLE
Refactor composer and collect action

### DIFF
--- a/apps/web/src/components/Composer/Editor/EditorHandle.tsx
+++ b/apps/web/src/components/Composer/Editor/EditorHandle.tsx
@@ -4,7 +4,7 @@ import type { Editor } from "prosekit/core";
 import type { FC, ReactNode } from "react";
 import { createContext, useContext, useEffect, useState } from "react";
 
-interface EditorHandle {
+export interface EditorHandle {
   insertText: (text: string) => void;
   setMarkdown: (markdown: string) => void;
 }

--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -1,46 +1,13 @@
-import NewAttachments from "@/components/Composer/NewAttachments";
-import QuotedPost from "@/components/Post/QuotedPost";
-import { AudioPostSchema } from "@/components/Shared/Audio";
-import Wrapper from "@/components/Shared/Embed/Wrapper";
-import EmojiPicker from "@/components/Shared/EmojiPicker";
-import { Button, Card, H6 } from "@/components/Shared/UI";
-import collectActionParams from "@/helpers/collectActionParams";
-import errorToast from "@/helpers/errorToast";
-import getMentions from "@/helpers/getMentions";
+import { Card } from "@/components/Shared/UI";
 import KeyboardShortcuts from "@/helpers/shortcuts";
-import uploadMetadata from "@/helpers/uploadMetadata";
-import useCreatePost from "@/hooks/useCreatePost";
-import usePostMetadata from "@/hooks/usePostMetadata";
-import { useNewPostModalStore } from "@/store/non-persisted/modal/useNewPostModalStore";
-import { useCollectActionStore } from "@/store/non-persisted/post/useCollectActionStore";
-import { usePostAttachmentStore } from "@/store/non-persisted/post/usePostAttachmentStore";
-import {
-  DEFAULT_AUDIO_POST,
-  usePostAudioStore
-} from "@/store/non-persisted/post/usePostAudioStore";
-import { usePostLicenseStore } from "@/store/non-persisted/post/usePostLicenseStore";
-import { usePostLiveStore } from "@/store/non-persisted/post/usePostLiveStore";
-import { usePostStore } from "@/store/non-persisted/post/usePostStore";
-import {
-  DEFAULT_VIDEO_THUMBNAIL,
-  usePostVideoStore
-} from "@/store/non-persisted/post/usePostVideoStore";
-import { useAccountStore } from "@/store/persisted/useAccountStore";
-import { Errors } from "@hey/data/errors";
-import getAccount from "@hey/helpers/getAccount";
+import useCreatePublication from "@/hooks/useCreatePublication";
 import type { PostFragment } from "@hey/indexer";
-import type { IGif } from "@hey/types/giphy";
-import type { NewAttachment } from "@hey/types/misc";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
-import { toast } from "sonner";
-import Attachment from "./Actions/Attachment";
-import CollectSettings from "./Actions/CollectSettings";
-import Gif from "./Actions/Gif";
-import LivestreamSettings from "./Actions/LivestreamSettings";
-import LivestreamEditor from "./Actions/LivestreamSettings/LivestreamEditor";
-import { Editor, useEditorContext, withEditorContext } from "./Editor";
-import LinkPreviews from "./LinkPreviews";
+import { useEditorContext, withEditorContext } from "./Editor";
+import AttachmentHandler from "./NewPublication/AttachmentHandler";
+import EditorArea from "./NewPublication/EditorArea";
+import SubmitActions from "./NewPublication/SubmitActions";
 
 interface NewPublicationProps {
   className?: string;
@@ -49,171 +16,20 @@ interface NewPublicationProps {
 }
 
 const NewPublication = ({ className, post, feed }: NewPublicationProps) => {
-  const { currentAccount } = useAccountStore();
-
-  // New post modal store
-  const { setShowNewPostModal } = useNewPostModalStore();
-
-  // Post store
-  const { postContent, quotedPost, setPostContent, setQuotedPost } =
-    usePostStore();
-
-  // Audio store
-  const { audioPost, setAudioPost } = usePostAudioStore();
-
-  // Video store
-  const { setVideoThumbnail, videoThumbnail } = usePostVideoStore();
-
-  // Live video store
-  const { resetLiveVideoConfig, setShowLiveVideoEditor, showLiveVideoEditor } =
-    usePostLiveStore();
-
-  // Attachment store
-  const { addAttachments, attachments, isUploading, setAttachments } =
-    usePostAttachmentStore((state) => state);
-
-  // License store
-  const { setLicense } = usePostLicenseStore();
-
-  // Collect module store
-  const { collectAction, reset: resetCollectSettings } = useCollectActionStore(
-    (state) => state
-  );
-
-  // States
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [showEmojiPicker, setShowEmojiPicker] = useState<boolean>(false);
-  const [postContentError, setPostContentError] = useState("");
-
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const editor = useEditorContext();
-  const getMetadata = usePostMetadata();
-
-  const isComment = Boolean(post);
-  const isQuote = Boolean(quotedPost);
-  const hasAudio = attachments[0]?.type === "Audio";
-  const hasVideo = attachments[0]?.type === "Video";
-
-  const reset = () => {
-    editor?.setMarkdown("");
-    setIsSubmitting(false);
-    setPostContent("");
-    setShowLiveVideoEditor(false);
-    resetLiveVideoConfig();
-    setAttachments([]);
-    setQuotedPost();
-    setVideoThumbnail(DEFAULT_VIDEO_THUMBNAIL);
-    setAudioPost(DEFAULT_AUDIO_POST);
-    setLicense(null);
-    resetCollectSettings();
-    setShowNewPostModal(false);
-  };
-
-  const onCompleted = () => {
-    reset();
-  };
-
-  const onError = (error?: any) => {
-    setIsSubmitting(false);
-    errorToast(error);
-  };
-
-  const { createPost } = useCreatePost({
-    commentOn: post,
-    onCompleted,
-    onError
-  });
-
-  useEffect(() => {
-    setPostContentError("");
-  }, [audioPost]);
-
-  useEffect(() => {
-    if (postContent.length > 25000) {
-      setPostContentError("Content should not exceed 25000 characters!");
-      return;
-    }
-
-    if (getMentions(postContent).length > 50) {
-      setPostContentError("You can only mention 50 people at a time!");
-      return;
-    }
-
-    setPostContentError("");
-  }, [postContent]);
-
-  const getTitlePrefix = () => {
-    if (hasVideo) {
-      return "Video";
-    }
-
-    return isComment ? "Comment" : isQuote ? "Quote" : "Post";
-  };
-
-  const handleCreatePost = async () => {
-    if (!currentAccount) {
-      return toast.error(Errors.SignWallet);
-    }
-
-    try {
-      setIsSubmitting(true);
-      if (hasAudio) {
-        setPostContentError("");
-        const parsedData = AudioPostSchema.safeParse(audioPost);
-        if (!parsedData.success) {
-          const issue = parsedData.error.issues[0];
-          setIsSubmitting(false);
-          return setPostContentError(issue.message);
-        }
-      }
-
-      if (!postContent.length && !attachments.length) {
-        setIsSubmitting(false);
-        return setPostContentError(
-          `${
-            isComment ? "Comment" : isQuote ? "Quote" : "Post"
-          } should not be empty!`
-        );
-      }
-
-      setPostContentError("");
-
-      const baseMetadata = {
-        content: postContent.length > 0 ? postContent : undefined,
-        title: hasAudio
-          ? audioPost.title
-          : `${getTitlePrefix()} by ${getAccount(currentAccount).usernameWithPrefix}`
-      };
-
-      const metadata = getMetadata({ baseMetadata });
-      const contentUri = await uploadMetadata(metadata);
-
-      return await createPost({
-        variables: {
-          request: {
-            contentUri,
-            ...(feed && { feed }),
-            ...(isComment && { commentOn: { post: post?.id } }),
-            ...(isQuote && { quoteOf: { post: quotedPost?.id } }),
-            ...(collectAction.enabled && {
-              actions: [{ ...collectActionParams(collectAction) }]
-            })
-          }
-        }
-      });
-    } catch (error) {
-      onError(error);
-    }
-  };
-
-  const setGifAttachment = (gif: IGif) => {
-    const attachment: NewAttachment = {
-      mimeType: "image/gif",
-      previewUri: gif.images.original.url,
-      type: "Image",
-      uri: gif.images.original.url
-    };
-    addAttachments([attachment]);
-  };
+  const {
+    attachments,
+    isUploading,
+    videoThumbnail,
+    showLiveVideoEditor,
+    isComment,
+    quotedPost,
+    postContentError,
+    handleCreatePost,
+    isSubmitting,
+    setGifAttachment
+  } = useCreatePublication({ post, feed });
 
   useHotkeys(KeyboardShortcuts.CreatePost.key, () => handleCreatePost(), {
     enableOnContentEditable: true
@@ -221,49 +37,33 @@ const NewPublication = ({ className, post, feed }: NewPublicationProps) => {
 
   return (
     <Card className={className} onClick={() => setShowEmojiPicker(false)}>
-      <Editor isComment={isComment} />
-      {postContentError ? (
-        <H6 className="mt-1 px-5 pb-3 text-red-500">{postContentError}</H6>
-      ) : null}
-      {showLiveVideoEditor ? <LivestreamEditor /> : null}
-      <LinkPreviews />
-      <NewAttachments attachments={attachments} />
-      {quotedPost ? (
-        <Wrapper className="m-5" zeroPadding>
-          <QuotedPost isNew post={quotedPost} />
-        </Wrapper>
-      ) : null}
+      <EditorArea
+        attachments={attachments}
+        isComment={isComment}
+        postContentError={postContentError}
+        quotedPost={quotedPost}
+        showLiveVideoEditor={showLiveVideoEditor}
+      />
       <div className="divider mx-5" />
       <div className="block items-center px-5 py-3 sm:flex">
-        <div className="flex items-center space-x-4">
-          <Attachment />
-          <EmojiPicker
-            setEmoji={(emoji: string) => {
-              setShowEmojiPicker(false);
-              editor?.insertText(emoji);
-            }}
-            setShowEmojiPicker={setShowEmojiPicker}
-            showEmojiPicker={showEmojiPicker}
-          />
-          <Gif setGifAttachment={(gif: IGif) => setGifAttachment(gif)} />
-          <CollectSettings />
-          {!isComment && <LivestreamSettings />}
-          {/* <GroupSettings /> */}
-        </div>
-        <div className="mt-2 ml-auto sm:mt-0">
-          <Button
-            disabled={
-              isSubmitting ||
-              isUploading ||
-              videoThumbnail.uploading ||
-              postContentError.length > 0
-            }
-            loading={isSubmitting}
-            onClick={handleCreatePost}
-          >
-            {isComment ? "Comment" : "Post"}
-          </Button>
-        </div>
+        <AttachmentHandler
+          editor={editor}
+          isComment={isComment}
+          setGifAttachment={setGifAttachment}
+          setShowEmojiPicker={setShowEmojiPicker}
+          showEmojiPicker={showEmojiPicker}
+        />
+        <SubmitActions
+          disabled={
+            isSubmitting ||
+            isUploading ||
+            videoThumbnail.uploading ||
+            postContentError.length > 0
+          }
+          handleSubmit={handleCreatePost}
+          isComment={isComment}
+          loading={isSubmitting}
+        />
       </div>
     </Card>
   );

--- a/apps/web/src/components/Composer/NewPublication/AttachmentHandler.tsx
+++ b/apps/web/src/components/Composer/NewPublication/AttachmentHandler.tsx
@@ -1,0 +1,41 @@
+import EmojiPicker from "@/components/Shared/EmojiPicker";
+import type { IGif } from "@hey/types/giphy";
+import type { Dispatch, SetStateAction } from "react";
+import Attachment from "../Actions/Attachment";
+import CollectSettings from "../Actions/CollectSettings";
+import Gif from "../Actions/Gif";
+import LivestreamSettings from "../Actions/LivestreamSettings";
+import type { EditorHandle } from "../Editor/EditorHandle";
+
+interface AttachmentHandlerProps {
+  editor: EditorHandle | null;
+  isComment: boolean;
+  setGifAttachment: (gif: IGif) => void;
+  showEmojiPicker: boolean;
+  setShowEmojiPicker: Dispatch<SetStateAction<boolean>>;
+}
+
+const AttachmentHandler = ({
+  editor,
+  isComment,
+  setGifAttachment,
+  showEmojiPicker,
+  setShowEmojiPicker
+}: AttachmentHandlerProps) => (
+  <div className="flex items-center space-x-4">
+    <Attachment />
+    <EmojiPicker
+      setEmoji={(emoji: string) => {
+        setShowEmojiPicker(false);
+        editor?.insertText(emoji);
+      }}
+      setShowEmojiPicker={setShowEmojiPicker}
+      showEmojiPicker={showEmojiPicker}
+    />
+    <Gif setGifAttachment={setGifAttachment} />
+    <CollectSettings />
+    {!isComment && <LivestreamSettings />}
+  </div>
+);
+
+export default AttachmentHandler;

--- a/apps/web/src/components/Composer/NewPublication/EditorArea.tsx
+++ b/apps/web/src/components/Composer/NewPublication/EditorArea.tsx
@@ -1,0 +1,42 @@
+import QuotedPost from "@/components/Post/QuotedPost";
+import Wrapper from "@/components/Shared/Embed/Wrapper";
+import { H6 } from "@/components/Shared/UI";
+import type { PostFragment } from "@hey/indexer";
+import type { NewAttachment } from "@hey/types/misc";
+import LivestreamEditor from "../Actions/LivestreamSettings/LivestreamEditor";
+import { Editor } from "../Editor";
+import LinkPreviews from "../LinkPreviews";
+import NewAttachments from "../NewAttachments";
+
+interface EditorAreaProps {
+  isComment: boolean;
+  attachments: NewAttachment[];
+  postContentError: string;
+  quotedPost?: PostFragment;
+  showLiveVideoEditor: boolean;
+}
+
+const EditorArea = ({
+  isComment,
+  attachments,
+  postContentError,
+  quotedPost,
+  showLiveVideoEditor
+}: EditorAreaProps) => (
+  <>
+    <Editor isComment={isComment} />
+    {postContentError ? (
+      <H6 className="mt-1 px-5 pb-3 text-red-500">{postContentError}</H6>
+    ) : null}
+    {showLiveVideoEditor ? <LivestreamEditor /> : null}
+    <LinkPreviews />
+    <NewAttachments attachments={attachments} />
+    {quotedPost ? (
+      <Wrapper className="m-5" zeroPadding>
+        <QuotedPost isNew post={quotedPost} />
+      </Wrapper>
+    ) : null}
+  </>
+);
+
+export default EditorArea;

--- a/apps/web/src/components/Composer/NewPublication/SubmitActions.tsx
+++ b/apps/web/src/components/Composer/NewPublication/SubmitActions.tsx
@@ -1,0 +1,23 @@
+import { Button } from "@/components/Shared/UI";
+
+interface SubmitActionsProps {
+  disabled: boolean;
+  loading: boolean;
+  isComment: boolean;
+  handleSubmit: () => void;
+}
+
+const SubmitActions = ({
+  disabled,
+  loading,
+  isComment,
+  handleSubmit
+}: SubmitActionsProps) => (
+  <div className="mt-2 ml-auto sm:mt-0">
+    <Button disabled={disabled} loading={loading} onClick={handleSubmit}>
+      {isComment ? "Comment" : "Post"}
+    </Button>
+  </div>
+);
+
+export default SubmitActions;

--- a/apps/web/src/components/Post/OpenAction/CollectAction/CollectActionBody.tsx
+++ b/apps/web/src/components/Post/OpenAction/CollectAction/CollectActionBody.tsx
@@ -1,5 +1,4 @@
 import CountdownTimer from "@/components/Shared/CountdownTimer";
-import Loader from "@/components/Shared/Loader";
 import PostExecutors from "@/components/Shared/Modal/PostExecutors";
 import Slug from "@/components/Shared/Slug";
 import {
@@ -23,239 +22,220 @@ import {
   UsersIcon
 } from "@heroicons/react/24/outline";
 import { BLOCK_EXPLORER_URL } from "@hey/data/constants";
-import { tokens } from "@hey/data/tokens";
 import formatAddress from "@hey/helpers/formatAddress";
 import getAccount from "@hey/helpers/getAccount";
-import { isRepost } from "@hey/helpers/postHelpers";
-import {
-  type AnyPostFragment,
-  type SimpleCollectActionFragment,
-  useCollectActionQuery
+import type {
+  AnyPostFragment,
+  PostFragment,
+  SimpleCollectActionFragment
 } from "@hey/indexer";
-import { useCounter } from "@uidotdev/usehooks";
 import plur from "plur";
-import { type Dispatch, type SetStateAction, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { Link } from "react-router";
 import CollectActionButton from "./CollectActionButton";
 import Splits from "./Splits";
 
 interface CollectActionBodyProps {
-  post: AnyPostFragment;
+  targetPost: AnyPostFragment;
+  collectAction: SimpleCollectActionFragment;
+  collects: number;
+  collectLimit: number;
+  percentageCollected: number;
+  currency?: string;
+  amount: number;
+  recipients: any[];
+  isTokenEnabled: boolean;
+  isSaleEnded: boolean;
+  isAllCollected: boolean;
+  endTimestamp?: string | null;
   setShowCollectModal: Dispatch<SetStateAction<boolean>>;
+  showCollectorsModal: boolean;
+  setShowCollectorsModal: Dispatch<SetStateAction<boolean>>;
+  increment: () => void;
 }
 
 const CollectActionBody = ({
-  post,
-  setShowCollectModal
-}: CollectActionBodyProps) => {
-  const [showCollectorsModal, setShowCollectorsModal] = useState(false);
-  const targetPost = isRepost(post) ? post?.repostOf : post;
-  const [collects, { increment }] = useCounter(targetPost.stats.collects);
-
-  const { data, loading } = useCollectActionQuery({
-    variables: { request: { post: post.id } }
-  });
-
-  if (loading) {
-    return <Loader className="my-10" />;
-  }
-
-  const targetAction =
-    data?.post?.__typename === "Post"
-      ? data?.post.actions.find(
-          (action) => action.__typename === "SimpleCollectAction"
-        )
-      : data?.post?.__typename === "Repost"
-        ? data?.post?.repostOf?.actions.find(
-            (action) => action.__typename === "SimpleCollectAction"
-          )
-        : null;
-
-  const collectAction = targetAction as SimpleCollectActionFragment;
-  const endTimestamp = collectAction?.endsAt;
-  const collectLimit = Number(collectAction?.collectLimit);
-  const amount = Number.parseFloat(
-    collectAction?.payToCollect?.price?.value || "0"
-  );
-  const currency = collectAction?.payToCollect?.price?.asset?.symbol;
-  const recipients = collectAction?.payToCollect?.recipients || [];
-  const percentageCollected = (collects / collectLimit) * 100;
-  const enabledTokens = tokens.map((t) => t.symbol);
-  const isTokenEnabled = enabledTokens?.includes(currency || "");
-  const isSaleEnded = endTimestamp
-    ? new Date(endTimestamp).getTime() / 1000 < new Date().getTime() / 1000
-    : false;
-  const isAllCollected = collectLimit ? collects >= collectLimit : false;
-
-  return (
-    <>
-      {collectLimit ? (
-        <Tooltip
-          content={`${percentageCollected.toFixed(0)}% Collected`}
-          placement="top"
-        >
-          <div className="h-2.5 w-full bg-gray-200 dark:bg-gray-700">
-            <div
-              className="h-2.5 bg-black dark:bg-white"
-              style={{ width: `${percentageCollected}%` }}
-            />
-          </div>
-        </Tooltip>
-      ) : null}
-      <div className="p-5">
-        {isAllCollected ? (
-          <WarningMessage
-            className="mb-5"
-            message={
-              <div className="flex items-center space-x-1.5">
-                <CheckCircleIcon className="size-4" />
-                <span>This collection has been sold out</span>
-              </div>
-            }
-          />
-        ) : isSaleEnded ? (
-          <WarningMessage
-            className="mb-5"
-            message={
-              <div className="flex items-center space-x-1.5">
-                <ClockIcon className="size-4" />
-                <span>This collection has ended</span>
-              </div>
-            }
-          />
-        ) : null}
-        <div className="mb-4">
-          <H4>
-            {targetPost.__typename} by{" "}
-            <Slug slug={getAccount(targetPost.author).usernameWithPrefix} />
-          </H4>
-        </div>
-        {amount ? (
-          <div className="flex items-center space-x-1.5 py-2">
-            {isTokenEnabled ? (
-              <img
-                alt={currency}
-                className="size-7 rounded-full"
-                height={28}
-                src={getTokenImage(currency)}
-                title={currency}
-                width={28}
-              />
-            ) : (
-              <CurrencyDollarIcon className="size-7" />
-            )}
-            <span className="space-x-1">
-              <H3 as="span">{amount}</H3>
-              <span className="text-xs">{currency}</span>
-            </span>
-            <div className="mt-2">
-              <HelpTooltip>
-                <div className="py-1">
-                  <div className="flex items-start justify-between space-x-10">
-                    <div>Hey</div>
-                    <b>
-                      ~{(amount * 0.025).toFixed(2)} {currency} (2.5%)
-                    </b>
-                  </div>
-                </div>
-              </HelpTooltip>
-            </div>
-          </div>
-        ) : null}
-        <div className="space-y-1.5">
-          <div className="block items-center space-y-1 sm:flex sm:space-x-5">
-            <div className="flex items-center space-x-2">
-              <UsersIcon className="size-4 text-gray-500 dark:text-gray-200" />
-              <button
-                className="font-bold"
-                onClick={() => setShowCollectorsModal(true)}
-                type="button"
-              >
-                {humanize(collects)} {plur("collector", collects)}
-              </button>
-            </div>
-            {collectLimit && !isAllCollected ? (
-              <div className="flex items-center space-x-2">
-                <PhotoIcon className="size-4 text-gray-500 dark:text-gray-200" />
-                <div className="font-bold">
-                  {collectLimit - collects} available
-                </div>
-              </div>
-            ) : null}
-          </div>
-          {endTimestamp && !isAllCollected ? (
-            <div className="flex items-center space-x-2">
-              <ClockIcon className="size-4 text-gray-500 dark:text-gray-200" />
-              <div className="space-x-1.5">
-                <span>{isSaleEnded ? "Sale ended on:" : "Sale ends:"}</span>
-                <span className="font-bold text-gray-600">
-                  {isSaleEnded ? (
-                    `${formatDate(endTimestamp, "MMM D, YYYY, hh:mm A")}`
-                  ) : (
-                    <CountdownTimer targetDate={endTimestamp} />
-                  )}
-                </span>
-              </div>
-            </div>
-          ) : null}
-          {collectAction.address ? (
-            <div className="flex items-center space-x-2">
-              <PuzzlePieceIcon className="size-4 text-gray-500 dark:text-gray-200" />
-              <div className="space-x-1.5">
-                <span>Token:</span>
-                <Link
-                  className="font-bold text-gray-600"
-                  to={`${BLOCK_EXPLORER_URL}/address/${collectAction.address}`}
-                  rel="noreferrer noopener"
-                  target="_blank"
-                >
-                  {formatAddress(collectAction.address)}
-                </Link>
-              </div>
-            </div>
-          ) : null}
-          {amount ? (
-            <div className="flex items-center space-x-2">
-              <CurrencyDollarIcon className="size-4 text-gray-500 dark:text-gray-200" />
-              <div className="space-x-1.5">
-                <span>Revenue:</span>
-                <Tooltip
-                  content={`${humanize(amount * collects)} ${currency}`}
-                  placement="top"
-                >
-                  <span className="font-bold text-gray-600">
-                    {nFormatter(amount * collects)} {currency}
-                  </span>
-                </Tooltip>
-              </div>
-            </div>
-          ) : null}
-          {recipients.length > 1 ? <Splits recipients={recipients} /> : null}
-        </div>
-        <div className="flex items-center space-x-2">
-          <CollectActionButton
-            collects={collects}
-            onCollectSuccess={() => {
-              increment();
-              setShowCollectModal(false);
-            }}
-            postAction={collectAction}
-            post={targetPost}
-          />
-        </div>
-      </div>
-      <Modal
-        onClose={() => setShowCollectorsModal(false)}
-        show={showCollectorsModal}
-        title="Collectors"
+  targetPost,
+  collectAction,
+  collects,
+  collectLimit,
+  percentageCollected,
+  currency,
+  amount,
+  recipients,
+  isTokenEnabled,
+  isSaleEnded,
+  isAllCollected,
+  endTimestamp,
+  setShowCollectModal,
+  showCollectorsModal,
+  setShowCollectorsModal,
+  increment
+}: CollectActionBodyProps) => (
+  <>
+    {collectLimit ? (
+      <Tooltip
+        content={`${percentageCollected.toFixed(0)}% Collected`}
+        placement="top"
       >
-        <PostExecutors
-          postId={targetPost.id}
-          filter={{ simpleCollect: true }}
+        <div className="h-2.5 w-full bg-gray-200 dark:bg-gray-700">
+          <div
+            className="h-2.5 bg-black dark:bg-white"
+            style={{ width: `${percentageCollected}%` }}
+          />
+        </div>
+      </Tooltip>
+    ) : null}
+    <div className="p-5">
+      {isAllCollected ? (
+        <WarningMessage
+          className="mb-5"
+          message={
+            <div className="flex items-center space-x-1.5">
+              <CheckCircleIcon className="size-4" />
+              <span>This collection has been sold out</span>
+            </div>
+          }
         />
-      </Modal>
-    </>
-  );
-};
+      ) : isSaleEnded ? (
+        <WarningMessage
+          className="mb-5"
+          message={
+            <div className="flex items-center space-x-1.5">
+              <ClockIcon className="size-4" />
+              <span>This collection has ended</span>
+            </div>
+          }
+        />
+      ) : null}
+      <div className="mb-4">
+        <H4>
+          {targetPost.__typename} by{" "}
+          <Slug slug={getAccount(targetPost.author).usernameWithPrefix} />
+        </H4>
+      </div>
+      {amount ? (
+        <div className="flex items-center space-x-1.5 py-2">
+          {isTokenEnabled ? (
+            <img
+              alt={currency}
+              className="size-7 rounded-full"
+              height={28}
+              src={getTokenImage(currency)}
+              title={currency}
+              width={28}
+            />
+          ) : (
+            <CurrencyDollarIcon className="size-7" />
+          )}
+          <span className="space-x-1">
+            <H3 as="span">{amount}</H3>
+            <span className="text-xs">{currency}</span>
+          </span>
+          <div className="mt-2">
+            <HelpTooltip>
+              <div className="py-1">
+                <div className="flex items-start justify-between space-x-10">
+                  <div>Hey</div>
+                  <b>
+                    ~{(amount * 0.025).toFixed(2)} {currency} (2.5%)
+                  </b>
+                </div>
+              </div>
+            </HelpTooltip>
+          </div>
+        </div>
+      ) : null}
+      <div className="space-y-1.5">
+        <div className="block items-center space-y-1 sm:flex sm:space-x-5">
+          <div className="flex items-center space-x-2">
+            <UsersIcon className="size-4 text-gray-500 dark:text-gray-200" />
+            <button
+              className="font-bold"
+              onClick={() => setShowCollectorsModal(true)}
+              type="button"
+            >
+              {humanize(collects)} {plur("collector", collects)}
+            </button>
+          </div>
+          {collectLimit && !isAllCollected ? (
+            <div className="flex items-center space-x-2">
+              <PhotoIcon className="size-4 text-gray-500 dark:text-gray-200" />
+              <div className="font-bold">
+                {collectLimit - collects} available
+              </div>
+            </div>
+          ) : null}
+        </div>
+        {endTimestamp && !isAllCollected ? (
+          <div className="flex items-center space-x-2">
+            <ClockIcon className="size-4 text-gray-500 dark:text-gray-200" />
+            <div className="space-x-1.5">
+              <span>{isSaleEnded ? "Sale ended on:" : "Sale ends:"}</span>
+              <span className="font-bold text-gray-600">
+                {isSaleEnded ? (
+                  `${formatDate(endTimestamp, "MMM D, YYYY, hh:mm A")}`
+                ) : (
+                  <CountdownTimer targetDate={endTimestamp} />
+                )}
+              </span>
+            </div>
+          </div>
+        ) : null}
+        {collectAction.address ? (
+          <div className="flex items-center space-x-2">
+            <PuzzlePieceIcon className="size-4 text-gray-500 dark:text-gray-200" />
+            <div className="space-x-1.5">
+              <span>Token:</span>
+              <Link
+                className="font-bold text-gray-600"
+                to={`${BLOCK_EXPLORER_URL}/address/${collectAction.address}`}
+                rel="noreferrer noopener"
+                target="_blank"
+              >
+                {formatAddress(collectAction.address)}
+              </Link>
+            </div>
+          </div>
+        ) : null}
+        {amount ? (
+          <div className="flex items-center space-x-2">
+            <CurrencyDollarIcon className="size-4 text-gray-500 dark:text-gray-200" />
+            <div className="space-x-1.5">
+              <span>Revenue:</span>
+              <Tooltip
+                content={`${humanize(amount * collects)} ${currency}`}
+                placement="top"
+              >
+                <span className="font-bold text-gray-600">
+                  {nFormatter(amount * collects)} {currency}
+                </span>
+              </Tooltip>
+            </div>
+          </div>
+        ) : null}
+        {recipients.length > 1 ? <Splits recipients={recipients} /> : null}
+      </div>
+      <div className="flex items-center space-x-2">
+        <CollectActionButton
+          collects={collects}
+          onCollectSuccess={() => {
+            increment();
+            setShowCollectModal(false);
+          }}
+          postAction={collectAction}
+          post={targetPost as PostFragment}
+        />
+      </div>
+    </div>
+    <Modal
+      onClose={() => setShowCollectorsModal(false)}
+      show={showCollectorsModal}
+      title="Collectors"
+    >
+      <PostExecutors postId={targetPost.id} filter={{ simpleCollect: true }} />
+    </Modal>
+  </>
+);
 
 export default CollectActionBody;

--- a/apps/web/src/components/Post/OpenAction/CollectAction/CollectActionData.tsx
+++ b/apps/web/src/components/Post/OpenAction/CollectAction/CollectActionData.tsx
@@ -1,0 +1,86 @@
+import Loader from "@/components/Shared/Loader";
+import { tokens } from "@hey/data/tokens";
+import { isRepost } from "@hey/helpers/postHelpers";
+import type {
+  AnyPostFragment,
+  SimpleCollectActionFragment
+} from "@hey/indexer";
+import { useCollectActionQuery } from "@hey/indexer";
+import { useCounter } from "@uidotdev/usehooks";
+import type { Dispatch, SetStateAction } from "react";
+import { useState } from "react";
+import CollectActionBody from "./CollectActionBody";
+
+interface CollectActionDataProps {
+  post: AnyPostFragment;
+  setShowCollectModal: Dispatch<SetStateAction<boolean>>;
+}
+
+const CollectActionData = ({
+  post,
+  setShowCollectModal
+}: CollectActionDataProps) => {
+  const [showCollectorsModal, setShowCollectorsModal] = useState(false);
+  const targetPost = isRepost(post) ? post.repostOf : post;
+  const [collects, { increment }] = useCounter(targetPost.stats.collects);
+
+  const { data, loading } = useCollectActionQuery({
+    variables: { request: { post: post.id } }
+  });
+
+  if (loading) {
+    return <Loader className="my-10" />;
+  }
+
+  const targetAction =
+    data?.post?.__typename === "Post"
+      ? data?.post.actions.find((a) => a.__typename === "SimpleCollectAction")
+      : data?.post?.__typename === "Repost"
+        ? data?.post.repostOf?.actions.find(
+            (a) => a.__typename === "SimpleCollectAction"
+          )
+        : null;
+
+  if (!targetAction) {
+    return null;
+  }
+
+  const collectAction = targetAction as SimpleCollectActionFragment;
+  const endTimestamp = collectAction.endsAt;
+  const collectLimit = Number(collectAction.collectLimit);
+  const amount = Number.parseFloat(
+    collectAction.payToCollect?.price?.value || "0"
+  );
+  const currency = collectAction.payToCollect?.price?.asset?.symbol;
+  const recipients = collectAction.payToCollect?.recipients || [];
+  const percentageCollected = (collects / collectLimit) * 100;
+  const enabledTokens = tokens.map((t) => t.symbol);
+  const isTokenEnabled = enabledTokens.includes(currency || "");
+  const isSaleEnded = endTimestamp
+    ? new Date(endTimestamp).getTime() / 1000 < new Date().getTime() / 1000
+    : false;
+  const isAllCollected = collectLimit ? collects >= collectLimit : false;
+
+  return (
+    <CollectActionBody
+      targetPost={targetPost}
+      collectAction={collectAction}
+      collects={collects}
+      collectLimit={collectLimit}
+      percentageCollected={percentageCollected}
+      currency={currency}
+      amount={amount}
+      recipients={recipients}
+      isTokenEnabled={isTokenEnabled}
+      isSaleEnded={isSaleEnded}
+      isAllCollected={isAllCollected}
+      endTimestamp={endTimestamp}
+      setShowCollectModal={setShowCollectModal}
+      showCollectorsModal={showCollectorsModal}
+      setShowCollectorsModal={setShowCollectorsModal}
+      increment={increment}
+    />
+  );
+};
+
+export default CollectActionData;

--- a/apps/web/src/components/Post/OpenAction/CollectAction/SmallCollectButton.tsx
+++ b/apps/web/src/components/Post/OpenAction/CollectAction/SmallCollectButton.tsx
@@ -1,7 +1,7 @@
 import { Button, Modal } from "@/components/Shared/UI";
 import type { PostFragment } from "@hey/indexer";
 import { useState } from "react";
-import CollectActionBody from "./CollectActionBody";
+import CollectActionData from "./CollectActionData";
 
 interface SmallCollectButtonProps {
   post: PostFragment;
@@ -25,7 +25,7 @@ const SmallCollectButton = ({ post }: SmallCollectButtonProps) => {
         show={showCollectModal}
         title="Collect"
       >
-        <CollectActionBody
+        <CollectActionData
           post={post}
           setShowCollectModal={setShowCollectModal}
         />

--- a/apps/web/src/components/Post/OpenAction/CollectAction/index.tsx
+++ b/apps/web/src/components/Post/OpenAction/CollectAction/index.tsx
@@ -5,7 +5,7 @@ import type { PostFragment } from "@hey/indexer";
 import { AnimateNumber } from "motion-plus-react";
 import plur from "plur";
 import { useState } from "react";
-import CollectActionBody from "./CollectActionBody";
+import CollectActionData from "./CollectActionData";
 
 interface CollectActionProps {
   post: PostFragment;
@@ -46,7 +46,7 @@ const CollectAction = ({ post }: CollectActionProps) => {
         show={showCollectModal}
         title="Collect"
       >
-        <CollectActionBody
+        <CollectActionData
           post={post}
           setShowCollectModal={setShowCollectModal}
         />

--- a/apps/web/src/hooks/useCreatePublication.tsx
+++ b/apps/web/src/hooks/useCreatePublication.tsx
@@ -1,0 +1,198 @@
+import { useEditorContext } from "@/components/Composer/Editor";
+import { AudioPostSchema } from "@/components/Shared/Audio";
+import collectActionParams from "@/helpers/collectActionParams";
+import errorToast from "@/helpers/errorToast";
+import getMentions from "@/helpers/getMentions";
+import uploadMetadata from "@/helpers/uploadMetadata";
+import useCreatePost from "@/hooks/useCreatePost";
+import usePostMetadata from "@/hooks/usePostMetadata";
+import { useNewPostModalStore } from "@/store/non-persisted/modal/useNewPostModalStore";
+import { useCollectActionStore } from "@/store/non-persisted/post/useCollectActionStore";
+import { usePostAttachmentStore } from "@/store/non-persisted/post/usePostAttachmentStore";
+import {
+  DEFAULT_AUDIO_POST,
+  usePostAudioStore
+} from "@/store/non-persisted/post/usePostAudioStore";
+import { usePostLicenseStore } from "@/store/non-persisted/post/usePostLicenseStore";
+import { usePostLiveStore } from "@/store/non-persisted/post/usePostLiveStore";
+import { usePostStore } from "@/store/non-persisted/post/usePostStore";
+import {
+  DEFAULT_VIDEO_THUMBNAIL,
+  usePostVideoStore
+} from "@/store/non-persisted/post/usePostVideoStore";
+import { useAccountStore } from "@/store/persisted/useAccountStore";
+import { Errors } from "@hey/data/errors";
+import getAccount from "@hey/helpers/getAccount";
+import type { PostFragment } from "@hey/indexer";
+import type { IGif } from "@hey/types/giphy";
+import type { NewAttachment } from "@hey/types/misc";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+interface UseCreatePublicationProps {
+  post?: PostFragment;
+  feed?: string;
+}
+
+const useCreatePublication = ({ post, feed }: UseCreatePublicationProps) => {
+  const { currentAccount } = useAccountStore();
+  const { setShowNewPostModal } = useNewPostModalStore();
+  const { postContent, quotedPost, setPostContent, setQuotedPost } =
+    usePostStore();
+  const { audioPost, setAudioPost } = usePostAudioStore();
+  const { setVideoThumbnail, videoThumbnail } = usePostVideoStore();
+  const { resetLiveVideoConfig, setShowLiveVideoEditor, showLiveVideoEditor } =
+    usePostLiveStore();
+  const { addAttachments, attachments, isUploading, setAttachments } =
+    usePostAttachmentStore((state) => state);
+  const { setLicense } = usePostLicenseStore();
+  const { collectAction, reset: resetCollectSettings } = useCollectActionStore(
+    (state) => state
+  );
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [postContentError, setPostContentError] = useState("");
+
+  const editor = useEditorContext();
+  const getMetadata = usePostMetadata();
+
+  const isComment = Boolean(post);
+  const isQuote = Boolean(quotedPost);
+  const hasAudio = attachments[0]?.type === "Audio";
+  const hasVideo = attachments[0]?.type === "Video";
+
+  const reset = () => {
+    editor?.setMarkdown("");
+    setIsSubmitting(false);
+    setPostContent("");
+    setShowLiveVideoEditor(false);
+    resetLiveVideoConfig();
+    setAttachments([]);
+    setQuotedPost();
+    setVideoThumbnail(DEFAULT_VIDEO_THUMBNAIL);
+    setAudioPost(DEFAULT_AUDIO_POST);
+    setLicense(null);
+    resetCollectSettings();
+    setShowNewPostModal(false);
+  };
+
+  const onCompleted = () => {
+    reset();
+  };
+
+  const onError = (error?: any) => {
+    setIsSubmitting(false);
+    errorToast(error);
+  };
+
+  const { createPost } = useCreatePost({
+    commentOn: post,
+    onCompleted,
+    onError
+  });
+
+  useEffect(() => {
+    setPostContentError("");
+  }, [audioPost]);
+
+  useEffect(() => {
+    if (postContent.length > 25000) {
+      setPostContentError("Content should not exceed 25000 characters!");
+      return;
+    }
+
+    if (getMentions(postContent).length > 50) {
+      setPostContentError("You can only mention 50 people at a time!");
+      return;
+    }
+
+    setPostContentError("");
+  }, [postContent]);
+
+  const getTitlePrefix = () => {
+    if (hasVideo) {
+      return "Video";
+    }
+
+    return isComment ? "Comment" : isQuote ? "Quote" : "Post";
+  };
+
+  const handleCreatePost = async () => {
+    if (!currentAccount) {
+      return toast.error(Errors.SignWallet);
+    }
+
+    try {
+      setIsSubmitting(true);
+      if (hasAudio) {
+        setPostContentError("");
+        const parsedData = AudioPostSchema.safeParse(audioPost);
+        if (!parsedData.success) {
+          const issue = parsedData.error.issues[0];
+          setIsSubmitting(false);
+          return setPostContentError(issue.message);
+        }
+      }
+
+      if (!postContent.length && !attachments.length) {
+        setIsSubmitting(false);
+        return setPostContentError(
+          `${isComment ? "Comment" : isQuote ? "Quote" : "Post"} should not be empty!`
+        );
+      }
+
+      setPostContentError("");
+
+      const baseMetadata = {
+        content: postContent.length > 0 ? postContent : undefined,
+        title: hasAudio
+          ? audioPost.title
+          : `${getTitlePrefix()} by ${getAccount(currentAccount).usernameWithPrefix}`
+      };
+
+      const metadata = getMetadata({ baseMetadata });
+      const contentUri = await uploadMetadata(metadata);
+
+      return await createPost({
+        variables: {
+          request: {
+            contentUri,
+            ...(feed && { feed }),
+            ...(isComment && { commentOn: { post: post?.id } }),
+            ...(isQuote && { quoteOf: { post: quotedPost?.id } }),
+            ...(collectAction.enabled && {
+              actions: [{ ...collectActionParams(collectAction) }]
+            })
+          }
+        }
+      });
+    } catch (error) {
+      onError(error);
+    }
+  };
+
+  const setGifAttachment = (gif: IGif) => {
+    const attachment: NewAttachment = {
+      mimeType: "image/gif",
+      previewUri: gif.images.original.url,
+      type: "Image",
+      uri: gif.images.original.url
+    };
+    addAttachments([attachment]);
+  };
+
+  return {
+    attachments,
+    isUploading,
+    videoThumbnail,
+    showLiveVideoEditor,
+    isComment,
+    quotedPost,
+    postContentError,
+    handleCreatePost,
+    isSubmitting,
+    setGifAttachment
+  };
+};
+
+export default useCreatePublication;


### PR DESCRIPTION
## Summary
- split `NewPublication` into smaller components
- extract composer network logic to `useCreatePublication`
- refactor collect action into data & presentational components
- expose `EditorHandle` type

## Testing
- `pnpm biome:check`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6843d3c6b8588330a968b60ab242a2c6