### PR TITLE
Use ApolloClientError for more handlers

### DIFF
--- a/apps/web/src/components/Group/Settings/Monetize/SuperJoin.tsx
+++ b/apps/web/src/components/Group/Settings/Monetize/SuperJoin.tsx
@@ -24,6 +24,7 @@ import {
   type GroupRules,
   useUpdateGroupRulesMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { type RefObject, useEffect, useRef, useState } from "react";
 
 interface SuperJoinProps {
@@ -54,7 +55,7 @@ const SuperJoin = ({ group }: SuperJoinProps) => {
     pollTransactionStatus(hash, () => location.reload());
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Group/Settings/Personalize/Form.tsx
+++ b/apps/web/src/components/Group/Settings/Personalize/Form.tsx
@@ -17,6 +17,7 @@ import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { Errors } from "@hey/data/errors";
 import { Regex } from "@hey/data/regex";
 import { type GroupFragment, useSetGroupMetadataMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { group as groupMetadata } from "@lens-protocol/metadata";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -54,7 +55,7 @@ const PersonalizeSettingsForm = ({ group }: PersonalizeSettingsFormProps) => {
     toast.success("Group updated");
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Group/Settings/Rules/ApprovalRule.tsx
+++ b/apps/web/src/components/Group/Settings/Rules/ApprovalRule.tsx
@@ -7,6 +7,7 @@ import {
   GroupRuleType,
   useUpdateGroupRulesMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -31,7 +32,7 @@ const ApprovalRule = ({ group }: ApprovalRuleProps) => {
     toast.success("Approval rule updated");
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Groups/Sidebar/Create/CreateGroupModal.tsx
+++ b/apps/web/src/components/Groups/Sidebar/Create/CreateGroupModal.tsx
@@ -11,6 +11,7 @@ import uploadMetadata from "@/helpers/uploadMetadata";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import { Regex } from "@hey/data/regex";
 import { useCreateGroupMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { group } from "@lens-protocol/metadata";
 import { useState } from "react";
 import { z } from "zod";
@@ -44,7 +45,7 @@ const CreateGroupModal = () => {
     setScreen("minting");
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Post/Actions/Like.tsx
+++ b/apps/web/src/components/Post/Actions/Like.tsx
@@ -12,6 +12,7 @@ import {
   useAddReactionMutation,
   useUndoReactionMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useCounter, useToggle } from "@uidotdev/usehooks";
 import { AnimateNumber } from "motion-plus-react";
 import { toast } from "sonner";
@@ -50,7 +51,7 @@ const Like = ({ post, showCount }: LikeProps) => {
     });
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     errorToast(error);
   };
 

--- a/apps/web/src/components/Post/Actions/Menu/Bookmark.tsx
+++ b/apps/web/src/components/Post/Actions/Menu/Bookmark.tsx
@@ -10,6 +10,7 @@ import {
   useBookmarkPostMutation,
   useUndoBookmarkPostMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useLocation } from "react-router";
 import { toast } from "sonner";
 
@@ -49,7 +50,7 @@ const Bookmark = ({ post }: BookmarkProps) => {
     }
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     errorToast(error);
   };
 

--- a/apps/web/src/components/Post/Actions/Menu/HideComment.tsx
+++ b/apps/web/src/components/Post/Actions/Menu/HideComment.tsx
@@ -11,6 +11,7 @@ import {
   useHideReplyMutation,
   useUnhideReplyMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { toast } from "sonner";
 
 interface HideCommentProps {
@@ -25,7 +26,7 @@ const HideComment = ({ post }: HideCommentProps) => {
     cache.evict({ id: cache.identify(post) });
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     errorToast(error);
   };
 

--- a/apps/web/src/components/Post/Actions/Menu/NotInterested.tsx
+++ b/apps/web/src/components/Post/Actions/Menu/NotInterested.tsx
@@ -10,6 +10,7 @@ import {
   useAddPostNotInterestedMutation,
   useUndoPostNotInterestedMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { toast } from "sonner";
 
 interface NotInterestedProps {
@@ -34,7 +35,7 @@ const NotInterested = ({ post }: NotInterestedProps) => {
     });
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     errorToast(error);
   };
 

--- a/apps/web/src/components/Post/Actions/Share/Repost.tsx
+++ b/apps/web/src/components/Post/Actions/Share/Repost.tsx
@@ -7,6 +7,7 @@ import { MenuItem } from "@headlessui/react";
 import { ArrowsRightLeftIcon } from "@heroicons/react/24/outline";
 import { Errors } from "@hey/data/errors";
 import { type PostFragment, useRepostMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useCounter } from "@uidotdev/usehooks";
 import type { Dispatch, SetStateAction } from "react";
 import { toast } from "sonner";
@@ -59,7 +60,7 @@ const Repost = ({ isSubmitting, post, setIsSubmitting }: RepostProps) => {
     toast.success("Post has been reposted!");
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Post/OpenAction/CollectAction/CollectActionButton.tsx
+++ b/apps/web/src/components/Post/OpenAction/CollectAction/CollectActionButton.tsx
@@ -13,6 +13,7 @@ import {
   useAccountBalancesQuery,
   useExecutePostActionMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -78,7 +79,7 @@ const CollectActionButton = ({
     toast.success("Collected successfully");
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Settings/Developer/Tokens.tsx
+++ b/apps/web/src/components/Settings/Developer/Tokens.tsx
@@ -5,6 +5,7 @@ import useHandleWrongNetwork from "@/hooks/useHandleWrongNetwork";
 import { hydrateAuthTokens } from "@/store/persisted/useAuthStore";
 import { Errors } from "@hey/data/errors";
 import { useAuthenticateMutation, useChallengeMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useAccount, useSignMessage } from "wagmi";
@@ -17,7 +18,7 @@ const Tokens = () => {
   const { address } = useAccount();
   const handleWrongNetwork = useHandleWrongNetwork();
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Settings/Manager/AccountManager/AddAccountManager.tsx
+++ b/apps/web/src/components/Settings/Manager/AccountManager/AddAccountManager.tsx
@@ -7,6 +7,7 @@ import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { ADDRESS_PLACEHOLDER } from "@hey/data/constants";
 import { Errors } from "@hey/data/errors";
 import { useAddAccountManagerMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import type { Dispatch, SetStateAction } from "react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -35,7 +36,7 @@ const AddAccountManager = ({
     });
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Settings/Manager/AccountManager/Managers/List.tsx
+++ b/apps/web/src/components/Settings/Manager/AccountManager/Managers/List.tsx
@@ -14,6 +14,7 @@ import {
   useAccountManagersQuery,
   useRemoveAccountManagerMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useIntersectionObserver } from "@uidotdev/usehooks";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -46,7 +47,7 @@ const List = () => {
     toast.success("Manager removed successfully");
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     errorToast(error);
     setRemovingManager(null);
   };

--- a/apps/web/src/components/Settings/Manager/Signless.tsx
+++ b/apps/web/src/components/Settings/Manager/Signless.tsx
@@ -2,6 +2,7 @@ import { Button, H6 } from "@/components/Shared/UI";
 import errorToast from "@/helpers/errorToast";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import { useEnableSignlessMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -14,7 +15,7 @@ const Signless = () => {
     toast.success("Signless enabled");
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Settings/Monetize/SuperFollow.tsx
+++ b/apps/web/src/components/Settings/Monetize/SuperFollow.tsx
@@ -26,6 +26,7 @@ import {
   useMeLazyQuery,
   useUpdateAccountFollowRulesMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { type RefObject, useEffect, useRef, useState } from "react";
 
 const SuperFollow = () => {
@@ -61,7 +62,7 @@ const SuperFollow = () => {
     });
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Settings/Personalize/Form.tsx
+++ b/apps/web/src/components/Settings/Personalize/Form.tsx
@@ -20,6 +20,7 @@ import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { Errors } from "@hey/data/errors";
 import { Regex } from "@hey/data/regex";
 import { useMeLazyQuery, useSetAccountMetadataMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import type {
   AccountOptions,
   MetadataAttribute
@@ -74,7 +75,7 @@ const PersonalizeSettingsForm = () => {
     });
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Settings/Sessions/List.tsx
+++ b/apps/web/src/components/Settings/Sessions/List.tsx
@@ -10,6 +10,7 @@ import {
   useAuthenticatedSessionsQuery,
   useRevokeAuthenticationMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useIntersectionObserver } from "@uidotdev/usehooks";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -27,7 +28,7 @@ const List = () => {
     rootMargin: "0px"
   });
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setRevoking(false);
     setRevokeingSessionId(null);
     errorToast(error);

--- a/apps/web/src/components/Settings/Username/LinkUsername.tsx
+++ b/apps/web/src/components/Settings/Username/LinkUsername.tsx
@@ -10,6 +10,7 @@ import {
   useAssignUsernameToAccountMutation,
   useUsernamesQuery
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -23,7 +24,7 @@ const LinkUsername = () => {
     toast.success("Linked");
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setLinkingUsername(null);
     errorToast(error);
   };

--- a/apps/web/src/components/Settings/Username/UnlinkUsername.tsx
+++ b/apps/web/src/components/Settings/Username/UnlinkUsername.tsx
@@ -4,6 +4,7 @@ import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import getAccount from "@hey/helpers/getAccount";
 import { useUnassignUsernameFromAccountMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -17,7 +18,7 @@ const UnlinkUsername = () => {
     toast.success("Unlinked");
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setUnlinking(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/Alert/BlockOrUnblockAccount.tsx
+++ b/apps/web/src/components/Shared/Alert/BlockOrUnblockAccount.tsx
@@ -7,6 +7,7 @@ import { useApolloClient } from "@apollo/client";
 import { Errors } from "@hey/data/errors";
 import getAccount from "@hey/helpers/getAccount";
 import { useBlockMutation, useUnblockMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -47,7 +48,7 @@ const BlockOrUnblockAccount = () => {
     );
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/Alert/DeletePost.tsx
+++ b/apps/web/src/components/Shared/Alert/DeletePost.tsx
@@ -4,6 +4,7 @@ import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import { useDeletePostAlertStore } from "@/store/non-persisted/alert/useDeletePostAlertStore";
 import { useApolloClient } from "@apollo/client";
 import { useDeletePostMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { toast } from "sonner";
 
 const DeletePost = () => {
@@ -24,7 +25,7 @@ const DeletePost = () => {
     toast.success("Post deleted");
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     errorToast(error);
   };
 

--- a/apps/web/src/components/Shared/Alert/MuteOrUnmuteAccount.tsx
+++ b/apps/web/src/components/Shared/Alert/MuteOrUnmuteAccount.tsx
@@ -6,6 +6,7 @@ import { useApolloClient } from "@apollo/client";
 import { Errors } from "@hey/data/errors";
 import getAccount from "@hey/helpers/getAccount";
 import { useMuteMutation, useUnmuteMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -42,7 +43,7 @@ const MuteOrUnmuteAccount = () => {
     toast.success(hasMuted ? "Unmuted successfully" : "Muted successfully");
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/Modal/Subscribe.tsx
+++ b/apps/web/src/components/Shared/Modal/Subscribe.tsx
@@ -17,6 +17,7 @@ import {
   useAccountBalancesQuery,
   useJoinGroupMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
 import SingleAccount from "../Account/SingleAccount";
 import TopUpButton from "../Account/TopUp/Button";
@@ -38,7 +39,7 @@ const Subscribe = () => {
     pollTransactionStatus(hash, () => location.reload());
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/Sidebar/ProBanner.tsx
+++ b/apps/web/src/components/Shared/Sidebar/ProBanner.tsx
@@ -5,6 +5,7 @@ import { useProStore } from "@/store/persisted/useProStore";
 import { CheckBadgeIcon, XCircleIcon } from "@heroicons/react/24/solid";
 import { BANNER_IDS } from "@hey/data/constants";
 import { useAddPostNotInterestedMutation } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { toast } from "sonner";
 
 const ProBanner = () => {
@@ -12,7 +13,7 @@ const ProBanner = () => {
   const { proBannerDismissed, setProBannerDismissed } = useProStore();
   // const { setShowProModal } = useProModalStore();
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     errorToast(error);
   };
 

--- a/apps/web/src/components/Shared/TipMenu.tsx
+++ b/apps/web/src/components/Shared/TipMenu.tsx
@@ -15,6 +15,7 @@ import {
   useExecuteAccountActionMutation,
   useExecutePostActionMutation
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import type { ChangeEvent, RefObject } from "react";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
@@ -74,7 +75,7 @@ const TipMenu = ({ closePopover, post, account }: TipMenuProps) => {
     toast.success(`Tipped ${amount} ${NATIVE_TOKEN_SYMBOL}`);
   };
 
-  const onError = (error: Error) => {
+  const onError = (error: ApolloClientError) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/hooks/useCreatePost.tsx
+++ b/apps/web/src/hooks/useCreatePost.tsx
@@ -5,6 +5,7 @@ import {
   useCreatePostMutation,
   usePostLazyQuery
 } from "@hey/indexer";
+import type { ApolloClientError } from "@hey/types/errors";
 import { useCallback } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
@@ -14,7 +15,7 @@ import useTransactionLifecycle from "./useTransactionLifecycle";
 interface CreatePostProps {
   commentOn?: PostFragment;
   onCompleted: () => void;
-  onError: (error: Error) => void;
+  onError: (error: ApolloClientError) => void;
 }
 
 const useCreatePost = ({


### PR DESCRIPTION
## Summary
- expand usage of `ApolloClientError` in mutation handlers
- keep imports sorted using Biome

## Testing
- `npx biome check .`
- `pnpm --recursive --parallel run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6843d6730fd48330a8cd60e51914faca