### PR TITLE
Setup vitest for web helpers

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "vite build",
     "dev": "vite dev --port 4783",
     "start": "vite preview --port 4783",
-    "typecheck": "tsc --pretty"
+    "typecheck": "tsc --pretty",
+    "test": "vitest"
   },
   "dependencies": {
     "@apollo/client": "^3.13.8",
@@ -82,6 +83,7 @@
     "autoprefixer": "^10.4.21",
     "typescript": "^5.8.3",
     "vite-plugin-environment": "^1.1.3",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.2.2"
   }
 }

--- a/apps/web/src/helpers/splitNumber.test.ts
+++ b/apps/web/src/helpers/splitNumber.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import splitNumber from "./splitNumber";
+
+describe("splitNumber", () => {
+  it("splits number evenly", () => {
+    expect(splitNumber(10, 3)).toEqual([4, 3, 3]);
+  });
+
+  it("handles default arguments", () => {
+    expect(splitNumber()).toEqual([1]);
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node"
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,9 @@ importers:
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0))
+      vitest:
+        specifier: ^3.2.2
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
 
   packages/config: {}
 


### PR DESCRIPTION
## Summary
- add `vitest` as a dev dependency for `@hey/web`
- create Vitest config file for the web app
- write first unit test for `splitNumber`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6843dcd4fad88330ab2eddd6d1e26b41