### PR TITLE
Implement exponential backoff for transaction polling

### DIFF
--- a/apps/web/src/components/Group/Settings/Monetize/SuperJoin.tsx
+++ b/apps/web/src/components/Group/Settings/Monetize/SuperJoin.tsx
@@ -51,8 +51,9 @@ const SuperJoin = ({ group }: SuperJoinProps) => {
     setAmount(simplePaymentAmount || 0);
   }, [simplePaymentAmount]);
 
-  const onCompleted = (hash: string) => {
-    pollTransactionStatus(hash, () => location.reload());
+  const onCompleted = async (hash: string) => {
+    await pollTransactionStatus(hash);
+    location.reload();
   };
 
   const onError = (error: ApolloClientError) => {

--- a/apps/web/src/components/Group/Settings/Monetize/SuperJoin.tsx
+++ b/apps/web/src/components/Group/Settings/Monetize/SuperJoin.tsx
@@ -9,9 +9,9 @@ import {
 } from "@/components/Shared/UI";
 import errorToast from "@/helpers/errorToast";
 import { getSimplePaymentDetails } from "@/helpers/rules";
-import usePollTransactionStatus from "@/hooks/usePollTransactionStatus";
 import usePreventScrollOnNumberInput from "@/hooks/usePreventScrollOnNumberInput";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
+import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import {
   DEFAULT_COLLECT_TOKEN,
   IS_MAINNET,
@@ -35,7 +35,7 @@ const SuperJoin = ({ group }: SuperJoinProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [amount, setAmount] = useState(0);
   const handleTransactionLifecycle = useTransactionLifecycle();
-  const pollTransactionStatus = usePollTransactionStatus();
+  const waitForTransactionToComplete = useWaitForTransactionToComplete();
   const inputRef = useRef<HTMLInputElement>(null);
   usePreventScrollOnNumberInput(inputRef as RefObject<HTMLInputElement>);
 
@@ -52,7 +52,7 @@ const SuperJoin = ({ group }: SuperJoinProps) => {
   }, [simplePaymentAmount]);
 
   const onCompleted = async (hash: string) => {
-    await pollTransactionStatus(hash);
+    await waitForTransactionToComplete(hash);
     location.reload();
   };
 

--- a/apps/web/src/components/Settings/Funds/Unwrap.tsx
+++ b/apps/web/src/components/Settings/Funds/Unwrap.tsx
@@ -20,13 +20,12 @@ const Unwrap = ({ value, refetch }: UnwrapProps) => {
   const handleTransactionLifecycle = useTransactionLifecycle();
   const pollTransactionStatus = usePollTransactionStatus();
 
-  const onCompleted = (hash: string) => {
+  const onCompleted = async (hash: string) => {
     setShowModal(false);
-    pollTransactionStatus(hash, () => {
-      setIsSubmitting(false);
-      refetch();
-      toast.success("Unwrap Successful");
-    });
+    await pollTransactionStatus(hash);
+    setIsSubmitting(false);
+    refetch();
+    toast.success("Unwrap Successful");
   };
 
   const onError = (error: ApolloClientError) => {

--- a/apps/web/src/components/Settings/Funds/Unwrap.tsx
+++ b/apps/web/src/components/Settings/Funds/Unwrap.tsx
@@ -1,7 +1,7 @@
 import { Button, Input, Modal } from "@/components/Shared/UI";
 import errorToast from "@/helpers/errorToast";
-import usePollTransactionStatus from "@/hooks/usePollTransactionStatus";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
+import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import { NATIVE_TOKEN_SYMBOL } from "@hey/data/constants";
 import { useUnwrapTokensMutation } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
@@ -18,11 +18,11 @@ const Unwrap = ({ value, refetch }: UnwrapProps) => {
   const [showModal, setShowModal] = useState(false);
   const [valueToUnwrap, setValueToUnwrap] = useState(value);
   const handleTransactionLifecycle = useTransactionLifecycle();
-  const pollTransactionStatus = usePollTransactionStatus();
+  const waitForTransactionToComplete = useWaitForTransactionToComplete();
 
   const onCompleted = async (hash: string) => {
     setShowModal(false);
-    await pollTransactionStatus(hash);
+    await waitForTransactionToComplete(hash);
     setIsSubmitting(false);
     refetch();
     toast.success("Unwrap Successful");

--- a/apps/web/src/components/Settings/Funds/Withdraw.tsx
+++ b/apps/web/src/components/Settings/Funds/Withdraw.tsx
@@ -21,13 +21,12 @@ const Withdraw = ({ currency, value, refetch }: WithdrawProps) => {
   const handleTransactionLifecycle = useTransactionLifecycle();
   const pollTransactionStatus = usePollTransactionStatus();
 
-  const onCompleted = (hash: string) => {
+  const onCompleted = async (hash: string) => {
     setShowModal(false);
-    pollTransactionStatus(hash, () => {
-      setIsSubmitting(false);
-      refetch();
-      toast.success("Withdrawal Successful");
-    });
+    await pollTransactionStatus(hash);
+    setIsSubmitting(false);
+    refetch();
+    toast.success("Withdrawal Successful");
   };
 
   const onError = (error: ApolloClientError) => {

--- a/apps/web/src/components/Settings/Funds/Withdraw.tsx
+++ b/apps/web/src/components/Settings/Funds/Withdraw.tsx
@@ -1,7 +1,7 @@
 import { Button, Input, Modal } from "@/components/Shared/UI";
 import errorToast from "@/helpers/errorToast";
-import usePollTransactionStatus from "@/hooks/usePollTransactionStatus";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
+import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import { useWithdrawMutation } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
@@ -19,11 +19,11 @@ const Withdraw = ({ currency, value, refetch }: WithdrawProps) => {
   const [showModal, setShowModal] = useState(false);
   const [valueToWithdraw, setValueToWithdraw] = useState(value);
   const handleTransactionLifecycle = useTransactionLifecycle();
-  const pollTransactionStatus = usePollTransactionStatus();
+  const waitForTransactionToComplete = useWaitForTransactionToComplete();
 
   const onCompleted = async (hash: string) => {
     setShowModal(false);
-    await pollTransactionStatus(hash);
+    await waitForTransactionToComplete(hash);
     setIsSubmitting(false);
     refetch();
     toast.success("Withdrawal Successful");

--- a/apps/web/src/components/Settings/Funds/Wrap.tsx
+++ b/apps/web/src/components/Settings/Funds/Wrap.tsx
@@ -1,7 +1,7 @@
 import { Button, Input, Modal } from "@/components/Shared/UI";
 import errorToast from "@/helpers/errorToast";
-import usePollTransactionStatus from "@/hooks/usePollTransactionStatus";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
+import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import { WRAPPED_NATIVE_TOKEN_SYMBOL } from "@hey/data/constants";
 import { useWrapTokensMutation } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
@@ -18,11 +18,11 @@ const Wrap = ({ value, refetch }: WrapProps) => {
   const [showModal, setShowModal] = useState(false);
   const [valueToWrap, setValueToWrap] = useState(value);
   const handleTransactionLifecycle = useTransactionLifecycle();
-  const pollTransactionStatus = usePollTransactionStatus();
+  const waitForTransactionToComplete = useWaitForTransactionToComplete();
 
   const onCompleted = async (hash: string) => {
     setShowModal(false);
-    await pollTransactionStatus(hash);
+    await waitForTransactionToComplete(hash);
     setIsSubmitting(false);
     refetch();
     toast.success("Wrap Successful");

--- a/apps/web/src/components/Settings/Funds/Wrap.tsx
+++ b/apps/web/src/components/Settings/Funds/Wrap.tsx
@@ -20,13 +20,12 @@ const Wrap = ({ value, refetch }: WrapProps) => {
   const handleTransactionLifecycle = useTransactionLifecycle();
   const pollTransactionStatus = usePollTransactionStatus();
 
-  const onCompleted = (hash: string) => {
+  const onCompleted = async (hash: string) => {
     setShowModal(false);
-    pollTransactionStatus(hash, () => {
-      setIsSubmitting(false);
-      refetch();
-      toast.success("Wrap Successful");
-    });
+    await pollTransactionStatus(hash);
+    setIsSubmitting(false);
+    refetch();
+    toast.success("Wrap Successful");
   };
 
   const onError = (error: ApolloClientError) => {

--- a/apps/web/src/components/Settings/Manager/AccountManager/AddAccountManager.tsx
+++ b/apps/web/src/components/Settings/Manager/AccountManager/AddAccountManager.tsx
@@ -26,14 +26,13 @@ const AddAccountManager = ({
   const handleTransactionLifecycle = useTransactionLifecycle();
   const pollTransactionStatus = usePollTransactionStatus();
 
-  const onCompleted = (hash: string) => {
+  const onCompleted = async (hash: string) => {
     setIsSubmitting(false);
     setShowAddManagerModal(false);
     const toastId = toast.loading("Adding manager...");
-    pollTransactionStatus(hash, () => {
-      toast.success("Manager added successfully", { id: toastId });
-      location.reload();
-    });
+    await pollTransactionStatus(hash);
+    toast.success("Manager added successfully", { id: toastId });
+    location.reload();
   };
 
   const onError = (error: ApolloClientError) => {

--- a/apps/web/src/components/Settings/Manager/AccountManager/AddAccountManager.tsx
+++ b/apps/web/src/components/Settings/Manager/AccountManager/AddAccountManager.tsx
@@ -1,8 +1,8 @@
 import SearchAccounts from "@/components/Shared/Account/SearchAccounts";
 import { Button } from "@/components/Shared/UI";
 import errorToast from "@/helpers/errorToast";
-import usePollTransactionStatus from "@/hooks/usePollTransactionStatus";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
+import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { ADDRESS_PLACEHOLDER } from "@hey/data/constants";
 import { Errors } from "@hey/data/errors";
@@ -24,13 +24,13 @@ const AddAccountManager = ({
   const [manager, setManager] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const handleTransactionLifecycle = useTransactionLifecycle();
-  const pollTransactionStatus = usePollTransactionStatus();
+  const waitForTransactionToComplete = useWaitForTransactionToComplete();
 
   const onCompleted = async (hash: string) => {
     setIsSubmitting(false);
     setShowAddManagerModal(false);
     const toastId = toast.loading("Adding manager...");
-    await pollTransactionStatus(hash);
+    await waitForTransactionToComplete(hash);
     toast.success("Manager added successfully", { id: toastId });
     location.reload();
   };

--- a/apps/web/src/components/Settings/Monetize/SuperFollow.tsx
+++ b/apps/web/src/components/Settings/Monetize/SuperFollow.tsx
@@ -54,12 +54,11 @@ const SuperFollow = () => {
     setAmount(simplePaymentAmount || 0);
   }, [simplePaymentAmount]);
 
-  const onCompleted = (hash: string) => {
-    pollTransactionStatus(hash, async () => {
-      const accountData = await getCurrentAccountDetails();
-      setCurrentAccount(accountData?.data?.me.loggedInAs.account);
-      location.reload();
-    });
+  const onCompleted = async (hash: string) => {
+    await pollTransactionStatus(hash);
+    const accountData = await getCurrentAccountDetails();
+    setCurrentAccount(accountData?.data?.me.loggedInAs.account);
+    location.reload();
   };
 
   const onError = (error: ApolloClientError) => {

--- a/apps/web/src/components/Settings/Monetize/SuperFollow.tsx
+++ b/apps/web/src/components/Settings/Monetize/SuperFollow.tsx
@@ -9,9 +9,9 @@ import {
 } from "@/components/Shared/UI";
 import errorToast from "@/helpers/errorToast";
 import { getSimplePaymentDetails } from "@/helpers/rules";
-import usePollTransactionStatus from "@/hooks/usePollTransactionStatus";
 import usePreventScrollOnNumberInput from "@/hooks/usePreventScrollOnNumberInput";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
+import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import {
   DEFAULT_COLLECT_TOKEN,
@@ -34,7 +34,7 @@ const SuperFollow = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [amount, setAmount] = useState(0);
   const handleTransactionLifecycle = useTransactionLifecycle();
-  const pollTransactionStatus = usePollTransactionStatus();
+  const waitForTransactionToComplete = useWaitForTransactionToComplete();
   const inputRef = useRef<HTMLInputElement>(null);
   usePreventScrollOnNumberInput(inputRef as RefObject<HTMLInputElement>);
   const [getCurrentAccountDetails] = useMeLazyQuery({
@@ -55,7 +55,7 @@ const SuperFollow = () => {
   }, [simplePaymentAmount]);
 
   const onCompleted = async (hash: string) => {
-    await pollTransactionStatus(hash);
+    await waitForTransactionToComplete(hash);
     const accountData = await getCurrentAccountDetails();
     setCurrentAccount(accountData?.data?.me.loggedInAs.account);
     location.reload();

--- a/apps/web/src/components/Settings/Personalize/Form.tsx
+++ b/apps/web/src/components/Settings/Personalize/Form.tsx
@@ -66,13 +66,12 @@ const PersonalizeSettingsForm = () => {
     fetchPolicy: "no-cache"
   });
 
-  const onCompleted = (hash: string) => {
-    pollTransactionStatus(hash, async () => {
-      const accountData = await getCurrentAccountDetails();
-      setCurrentAccount(accountData?.data?.me.loggedInAs.account);
-      setIsSubmitting(false);
-      toast.success("Account updated");
-    });
+  const onCompleted = async (hash: string) => {
+    await pollTransactionStatus(hash);
+    const accountData = await getCurrentAccountDetails();
+    setCurrentAccount(accountData?.data?.me.loggedInAs.account);
+    setIsSubmitting(false);
+    toast.success("Account updated");
   };
 
   const onError = (error: ApolloClientError) => {

--- a/apps/web/src/components/Settings/Personalize/Form.tsx
+++ b/apps/web/src/components/Settings/Personalize/Form.tsx
@@ -14,8 +14,8 @@ import errorToast from "@/helpers/errorToast";
 import getAccountAttribute from "@/helpers/getAccountAttribute";
 import trimify from "@/helpers/trimify";
 import uploadMetadata from "@/helpers/uploadMetadata";
-import usePollTransactionStatus from "@/hooks/usePollTransactionStatus";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
+import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { Errors } from "@hey/data/errors";
 import { Regex } from "@hey/data/regex";
@@ -61,13 +61,13 @@ const PersonalizeSettingsForm = () => {
     currentAccount?.metadata?.coverPicture
   );
   const handleTransactionLifecycle = useTransactionLifecycle();
-  const pollTransactionStatus = usePollTransactionStatus();
+  const waitForTransactionToComplete = useWaitForTransactionToComplete();
   const [getCurrentAccountDetails] = useMeLazyQuery({
     fetchPolicy: "no-cache"
   });
 
   const onCompleted = async (hash: string) => {
-    await pollTransactionStatus(hash);
+    await waitForTransactionToComplete(hash);
     const accountData = await getCurrentAccountDetails();
     setCurrentAccount(accountData?.data?.me.loggedInAs.account);
     setIsSubmitting(false);

--- a/apps/web/src/components/Shared/Account/TopUp/Transfer.tsx
+++ b/apps/web/src/components/Shared/Account/TopUp/Transfer.tsx
@@ -1,8 +1,8 @@
 import { Button, Card, Input, Spinner } from "@/components/Shared/UI";
 import errorToast from "@/helpers/errorToast";
-import usePollTransactionStatus from "@/hooks/usePollTransactionStatus";
 import usePreventScrollOnNumberInput from "@/hooks/usePreventScrollOnNumberInput";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
+import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import {
   type FundingToken,
   useFundModalStore
@@ -28,7 +28,7 @@ const Transfer = ({ token }: TransferProps) => {
   usePreventScrollOnNumberInput(inputRef as RefObject<HTMLInputElement>);
   const { address } = useAccount();
   const handleTransactionLifecycle = useTransactionLifecycle();
-  const pollTransactionStatus = usePollTransactionStatus();
+  const waitForTransactionToComplete = useWaitForTransactionToComplete();
   const symbol = token?.symbol ?? NATIVE_TOKEN_SYMBOL;
 
   const { data: balance, isLoading: balanceLoading } = useBalance({
@@ -40,7 +40,7 @@ const Transfer = ({ token }: TransferProps) => {
   const onCompleted = async (hash: string) => {
     setAmount(2);
     setOther(false);
-    await pollTransactionStatus(hash);
+    await waitForTransactionToComplete(hash);
     setIsSubmitting(false);
     setShowFundModal(false);
     toast.success("Transferred successfully");

--- a/apps/web/src/components/Shared/Account/TopUp/Transfer.tsx
+++ b/apps/web/src/components/Shared/Account/TopUp/Transfer.tsx
@@ -37,14 +37,13 @@ const Transfer = ({ token }: TransferProps) => {
     query: { refetchInterval: 2000 }
   });
 
-  const onCompleted = (hash: string) => {
+  const onCompleted = async (hash: string) => {
     setAmount(2);
     setOther(false);
-    pollTransactionStatus(hash, () => {
-      setIsSubmitting(false);
-      setShowFundModal(false);
-      toast.success("Transferred successfully");
-    });
+    await pollTransactionStatus(hash);
+    setIsSubmitting(false);
+    setShowFundModal(false);
+    toast.success("Transferred successfully");
   };
 
   const onError = (error: ApolloClientError) => {

--- a/apps/web/src/components/Shared/Modal/Subscribe.tsx
+++ b/apps/web/src/components/Shared/Modal/Subscribe.tsx
@@ -1,8 +1,8 @@
 import { Button, Image, Spinner, Tooltip } from "@/components/Shared/UI";
 import errorToast from "@/helpers/errorToast";
 import getTokenImage from "@/helpers/getTokenImage";
-import usePollTransactionStatus from "@/hooks/usePollTransactionStatus";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
+import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { CheckCircleIcon } from "@heroicons/react/24/outline";
 import {
@@ -26,7 +26,7 @@ const Subscribe = () => {
   const { currentAccount } = useAccountStore();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const handleTransactionLifecycle = useTransactionLifecycle();
-  const pollTransactionStatus = usePollTransactionStatus();
+  const waitForTransactionToComplete = useWaitForTransactionToComplete();
 
   const { data: balance, loading: balanceLoading } = useAccountBalancesQuery({
     variables: { request: { tokens: [DEFAULT_COLLECT_TOKEN] } },
@@ -36,7 +36,7 @@ const Subscribe = () => {
   });
 
   const onCompleted = async (hash: string) => {
-    await pollTransactionStatus(hash);
+    await waitForTransactionToComplete(hash);
     location.reload();
   };
 

--- a/apps/web/src/components/Shared/Modal/Subscribe.tsx
+++ b/apps/web/src/components/Shared/Modal/Subscribe.tsx
@@ -35,8 +35,9 @@ const Subscribe = () => {
     fetchPolicy: "no-cache"
   });
 
-  const onCompleted = (hash: string) => {
-    pollTransactionStatus(hash, () => location.reload());
+  const onCompleted = async (hash: string) => {
+    await pollTransactionStatus(hash);
+    location.reload();
   };
 
   const onError = (error: ApolloClientError) => {

--- a/apps/web/src/hooks/useCreatePost.tsx
+++ b/apps/web/src/hooks/useCreatePost.tsx
@@ -60,7 +60,7 @@ const useCreatePost = ({
       const toastId = toast.loading(
         `${isComment ? "Comment" : "Post"} processing...`
       );
-      pollTransactionStatus(hash, () => updateCache(hash, toastId));
+      pollTransactionStatus(hash).then(() => updateCache(hash, toastId));
       return onCompleted();
     },
     [pollTransactionStatus, updateCache, onCompleted, isComment]

--- a/apps/web/src/hooks/useCreatePost.tsx
+++ b/apps/web/src/hooks/useCreatePost.tsx
@@ -9,8 +9,8 @@ import type { ApolloClientError } from "@hey/types/errors";
 import { useCallback } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
-import usePollTransactionStatus from "./usePollTransactionStatus";
 import useTransactionLifecycle from "./useTransactionLifecycle";
+import useWaitForTransactionToComplete from "./useWaitForTransactionToComplete";
 
 interface CreatePostProps {
   commentOn?: PostFragment;
@@ -25,7 +25,7 @@ const useCreatePost = ({
 }: CreatePostProps) => {
   const navigate = useNavigate();
   const handleTransactionLifecycle = useTransactionLifecycle();
-  const pollTransactionStatus = usePollTransactionStatus();
+  const waitForTransactionToComplete = useWaitForTransactionToComplete();
   const [getPost] = usePostLazyQuery();
   const { cache } = useApolloClient();
   const isComment = Boolean(commentOn);
@@ -60,10 +60,10 @@ const useCreatePost = ({
       const toastId = toast.loading(
         `${isComment ? "Comment" : "Post"} processing...`
       );
-      pollTransactionStatus(hash).then(() => updateCache(hash, toastId));
+      waitForTransactionToComplete(hash).then(() => updateCache(hash, toastId));
       return onCompleted();
     },
-    [pollTransactionStatus, updateCache, onCompleted, isComment]
+    [waitForTransactionToComplete, updateCache, onCompleted, isComment]
   );
 
   // Onchain mutations

--- a/apps/web/src/hooks/useWaitForTransactionToComplete.tsx
+++ b/apps/web/src/hooks/useWaitForTransactionToComplete.tsx
@@ -5,12 +5,12 @@ const INITIAL_DELAY = 1000;
 const MAX_DELAY = 10000;
 const MAX_TIMEOUT = 60000;
 
-const usePollTransactionStatus = () => {
+const useWaitForTransactionToComplete = () => {
   const [getTransactionStatus] = useTransactionStatusLazyQuery({
     fetchPolicy: "no-cache"
   });
 
-  const pollTransactionStatus = useCallback(
+  const waitForTransactionToComplete = useCallback(
     async (hash: string, timeout = MAX_TIMEOUT) => {
       let delay = INITIAL_DELAY;
       const startTime = Date.now();
@@ -33,7 +33,7 @@ const usePollTransactionStatus = () => {
     [getTransactionStatus]
   );
 
-  return pollTransactionStatus;
+  return waitForTransactionToComplete;
 };
 
-export default usePollTransactionStatus;
+export default useWaitForTransactionToComplete;


### PR DESCRIPTION
## Summary
- use exponential backoff when polling transaction status
- update transaction polling usage across the app

## Testing
- `pnpm biome:check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6843e024917c83308121f87ecd811981