### PR TITLE
Add helper tests

### DIFF
--- a/apps/web/src/helpers/cn.test.ts
+++ b/apps/web/src/helpers/cn.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import cn from "./cn";
+
+describe("cn", () => {
+  it("merges class names and removes duplicates", () => {
+    expect(cn("p-2", "p-4", "p-2")).toBe("p-2");
+  });
+
+  it("ignores falsy values", () => {
+    expect(cn("text-sm", null as any, undefined as any, false as any)).toBe(
+      "text-sm"
+    );
+  });
+});

--- a/apps/web/src/helpers/collectActionParams.test.ts
+++ b/apps/web/src/helpers/collectActionParams.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import collectActionParams from "./collectActionParams";
+
+describe("collectActionParams", () => {
+  it("maps collect action fields", () => {
+    const input = { payToCollect: true, collectLimit: 3, endsAt: "now" } as any;
+    expect(collectActionParams(input)).toEqual({
+      simpleCollect: { payToCollect: true, collectLimit: 3, endsAt: "now" }
+    });
+  });
+});

--- a/apps/web/src/helpers/convertToTitleCase.test.ts
+++ b/apps/web/src/helpers/convertToTitleCase.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import convertToTitleCase from "./convertToTitleCase";
+
+describe("convertToTitleCase", () => {
+  it("handles snake case", () => {
+    expect(convertToTitleCase("hello_world")).toBe("Hello World");
+  });
+
+  it("handles camel case", () => {
+    expect(convertToTitleCase("helloWorld")).toBe("Hello World");
+  });
+
+  it("handles uppercase", () => {
+    expect(convertToTitleCase("FOO")).toBe("F O O");
+  });
+});

--- a/apps/web/src/helpers/getAccountAttribute.test.ts
+++ b/apps/web/src/helpers/getAccountAttribute.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import getAccountAttribute from "./getAccountAttribute";
+
+describe("getAccountAttribute", () => {
+  const attrs = [
+    { key: "location", value: "mars" },
+    { key: "website", value: "https://hey.xyz" }
+  ] as any;
+
+  it("returns empty string when not found", () => {
+    expect(getAccountAttribute("x", attrs)).toBe("");
+  });
+
+  it("finds value by key", () => {
+    expect(getAccountAttribute("location", attrs)).toBe("mars");
+  });
+});

--- a/apps/web/src/helpers/getAnyKeyValue.test.ts
+++ b/apps/web/src/helpers/getAnyKeyValue.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import getAnyKeyValue from "./getAnyKeyValue";
+
+describe("getAnyKeyValue", () => {
+  const data = [
+    { __typename: "AddressKeyValue", key: "addr", address: "0x1" },
+    { __typename: "BigDecimalKeyValue", key: "amount", bigDecimal: "1.5" },
+    { __typename: "StringKeyValue", key: "name", string: "alice" }
+  ] as any;
+
+  it("returns null when key not found", () => {
+    expect(getAnyKeyValue(data, "missing")).toBeNull();
+  });
+
+  it("returns address value", () => {
+    expect(getAnyKeyValue(data, "addr")).toEqual({ address: "0x1" });
+  });
+
+  it("returns bigDecimal value", () => {
+    expect(getAnyKeyValue(data, "amount")).toEqual({ bigDecimal: "1.5" });
+  });
+
+  it("returns string value", () => {
+    expect(getAnyKeyValue(data, "name")).toEqual({ string: "alice" });
+  });
+});

--- a/apps/web/src/helpers/getAssetLicense.test.ts
+++ b/apps/web/src/helpers/getAssetLicense.test.ts
@@ -1,0 +1,33 @@
+import { MetadataLicenseType } from "@hey/indexer";
+import { describe, expect, it } from "vitest";
+import getAssetLicense from "./getAssetLicense";
+
+describe("getAssetLicense", () => {
+  it("returns null when id missing", () => {
+    expect(getAssetLicense(undefined)).toBeNull();
+  });
+
+  it("handles CC0", () => {
+    expect(getAssetLicense(MetadataLicenseType.Cco)).toEqual({
+      helper:
+        "Anyone can use, modify and distribute the work without any restrictions or need for attribution. CC0",
+      label: "CC0 - no restrictions"
+    });
+  });
+
+  it("handles commercial rights", () => {
+    expect(getAssetLicense(MetadataLicenseType.TbnlCdNplLegal)).toEqual({
+      helper:
+        "You allow the collector to use the content for any purpose, except creating or sharing any derivative works, such as remixes.",
+      label: "Commercial rights for the collector"
+    });
+  });
+
+  it("handles personal rights", () => {
+    expect(getAssetLicense(MetadataLicenseType.TbnlNcDNplLegal)).toEqual({
+      helper:
+        "You allow the collector to use the content for any personal, non-commercial purpose, except creating or sharing any derivative works, such as remixes.",
+      label: "Personal rights for the collector"
+    });
+  });
+});

--- a/apps/web/src/helpers/getBlockedMessage.test.ts
+++ b/apps/web/src/helpers/getBlockedMessage.test.ts
@@ -1,0 +1,23 @@
+import { LENS_NAMESPACE } from "@hey/data/constants";
+import type { AccountFragment } from "@hey/indexer";
+import { describe, expect, it } from "vitest";
+import {
+  getBlockedByMeMessage,
+  getBlockedMeMessage
+} from "./getBlockedMessage";
+
+const account = {
+  address: "0x1",
+  owner: "0x1",
+  username: { value: `${LENS_NAMESPACE}alice`, localName: "alice" }
+} as AccountFragment;
+
+describe("getBlockedMessage", () => {
+  it("formats blocked by me message", () => {
+    expect(getBlockedByMeMessage(account)).toBe("You have blocked @alice");
+  });
+
+  it("formats blocked me message", () => {
+    expect(getBlockedMeMessage(account)).toBe("@alice has blocked you");
+  });
+});

--- a/apps/web/src/helpers/getCollectActionData.test.ts
+++ b/apps/web/src/helpers/getCollectActionData.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import getCollectActionData from "./getCollectActionData";
+
+describe("getCollectActionData", () => {
+  it("returns null for unknown type", () => {
+    expect(getCollectActionData({ __typename: "Other" } as any)).toBeNull();
+  });
+
+  it("parses simple collect action", () => {
+    const action = {
+      __typename: "SimpleCollectAction",
+      collectLimit: 10,
+      endsAt: "date",
+      payToCollect: {
+        price: {
+          value: "1",
+          asset: { contract: { address: "0x1" }, symbol: "AAA" }
+        },
+        recipients: []
+      }
+    } as any;
+    expect(getCollectActionData(action)).toEqual({
+      price: 1,
+      assetAddress: "0x1",
+      assetSymbol: "AAA",
+      collectLimit: 10,
+      endsAt: "date",
+      recipients: []
+    });
+  });
+});

--- a/apps/web/src/helpers/getFavicon.test.ts
+++ b/apps/web/src/helpers/getFavicon.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import getFavicon from "./getFavicon";
+
+const BASE = "https://external-content.duckduckgo.com/ip3";
+
+describe("getFavicon", () => {
+  it("returns favicon for valid url", () => {
+    expect(getFavicon("https://hey.xyz")).toBe(`${BASE}/hey.xyz.ico`);
+  });
+
+  it("handles invalid url", () => {
+    expect(getFavicon("not a url")).toBe(`${BASE}/unknowndomain.ico`);
+  });
+
+  it("handles empty input", () => {
+    expect(getFavicon("")).toBe(`${BASE}/unknowndomain.ico`);
+  });
+});

--- a/apps/web/src/helpers/getMentions.test.ts
+++ b/apps/web/src/helpers/getMentions.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import getMentions from "./getMentions";
+
+describe("getMentions", () => {
+  it("returns empty array for empty text", () => {
+    expect(getMentions("")).toEqual([]);
+  });
+
+  it("extracts mentions", () => {
+    const mentions = getMentions("hi @lens/alice and @lens/bob");
+    expect(mentions.map((m) => m.replace.from)).toEqual(["alice", "bob"]);
+  });
+});

--- a/apps/web/src/helpers/getTokenImage.test.ts
+++ b/apps/web/src/helpers/getTokenImage.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import getTokenImage from "./getTokenImage";
+
+describe("getTokenImage", () => {
+  it("defaults to gho icon", () => {
+    expect(getTokenImage()).toContain("gho.svg");
+  });
+
+  it("uses lowercase symbol", () => {
+    expect(getTokenImage("USDC")).toContain("usdc.svg");
+  });
+});

--- a/apps/web/src/helpers/getURLs.test.ts
+++ b/apps/web/src/helpers/getURLs.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import getURLs from "./getURLs";
+
+describe("getURLs", () => {
+  it("returns empty array when text is empty", () => {
+    expect(getURLs("")).toEqual([]);
+  });
+
+  it("extracts urls from text", () => {
+    const urls = getURLs("visit https://a.com and http://b.com");
+    expect(urls).toEqual(["https://a.com", "http://b.com"]);
+  });
+});

--- a/apps/web/src/helpers/getWalletDetails.test.ts
+++ b/apps/web/src/helpers/getWalletDetails.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import getWalletDetails from "./getWalletDetails";
+
+describe("getWalletDetails", () => {
+  it("returns details for walletConnect", () => {
+    expect(getWalletDetails("walletConnect")).toMatchObject({
+      name: "Wallet Connect"
+    });
+  });
+
+  it("returns details for injected", () => {
+    expect(getWalletDetails("injected")).toMatchObject({
+      name: "Browser Wallet"
+    });
+  });
+});

--- a/apps/web/src/helpers/humanize.test.ts
+++ b/apps/web/src/helpers/humanize.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import humanize from "./humanize";
+
+describe("humanize", () => {
+  it("formats finite numbers", () => {
+    expect(humanize(1234)).toBe("1,234");
+  });
+
+  it("returns empty string for invalid", () => {
+    expect(humanize(Number.POSITIVE_INFINITY)).toBe("");
+  });
+});

--- a/apps/web/src/helpers/injectReferrerToUrl.test.ts
+++ b/apps/web/src/helpers/injectReferrerToUrl.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import injectReferrerToUrl from "./injectReferrerToUrl";
+
+const BASE = "https://example.com";
+
+describe("injectReferrerToUrl", () => {
+  it("returns original for invalid url", () => {
+    expect(injectReferrerToUrl("not a url")).toBe("not a url");
+  });
+
+  it("adds referrer param for supported domain", () => {
+    const url = injectReferrerToUrl("https://zora.co/collect");
+    expect(url).toContain("referrer=");
+  });
+
+  it("leaves other domains unchanged", () => {
+    const url = `${BASE}/path`;
+    expect(injectReferrerToUrl(url)).toBe(url);
+  });
+});

--- a/apps/web/src/helpers/nFormatter.test.ts
+++ b/apps/web/src/helpers/nFormatter.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import nFormatter from "./nFormatter";
+
+describe("nFormatter", () => {
+  it("returns empty string for invalid number", () => {
+    expect(nFormatter(Number.POSITIVE_INFINITY)).toBe("");
+  });
+
+  it("formats small numbers", () => {
+    expect(nFormatter(999)).toBe("999");
+  });
+
+  it("formats large numbers", () => {
+    expect(nFormatter(1500)).toBe("1.5k");
+  });
+});

--- a/apps/web/src/helpers/rules.test.ts
+++ b/apps/web/src/helpers/rules.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { getSimplePaymentDetails } from "./rules";
+
+describe("getSimplePaymentDetails", () => {
+  const rule = {
+    type: "SIMPLE_PAYMENT",
+    config: [
+      { __typename: "AddressKeyValue", key: "assetContract", address: "0x1" },
+      { __typename: "StringKeyValue", key: "assetSymbol", string: "USD" },
+      { __typename: "BigDecimalKeyValue", key: "amount", bigDecimal: "5" }
+    ]
+  } as any;
+
+  it("extracts payment details", () => {
+    const rules = { required: [rule], anyOf: [] } as any;
+    expect(getSimplePaymentDetails(rules)).toEqual({
+      assetAddress: "0x1",
+      assetSymbol: "USD",
+      amount: 5
+    });
+  });
+
+  it("returns null fields when not found", () => {
+    const rules = { required: [], anyOf: [] } as any;
+    expect(getSimplePaymentDetails(rules)).toEqual({
+      assetAddress: null,
+      assetSymbol: null,
+      amount: null
+    });
+  });
+});

--- a/apps/web/src/helpers/stopEventPropagation.test.ts
+++ b/apps/web/src/helpers/stopEventPropagation.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it, vi } from "vitest";
+import stopEventPropagation from "./stopEventPropagation";
+
+describe("stopEventPropagation", () => {
+  it("calls stopPropagation", () => {
+    const event = { stopPropagation: vi.fn() } as any;
+    stopEventPropagation(event);
+    expect(event.stopPropagation).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/helpers/trimify.test.ts
+++ b/apps/web/src/helpers/trimify.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import trimify from "./trimify";
+
+describe("trimify", () => {
+  it("removes extra newlines and trims", () => {
+    const input = "a\n\n\n b \n";
+    expect(trimify(input)).toBe("a\n\n b");
+  });
+});

--- a/apps/web/src/helpers/truncateByWords.test.ts
+++ b/apps/web/src/helpers/truncateByWords.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import truncateByWords from "./truncateByWords";
+
+describe("truncateByWords", () => {
+  it("returns original when short", () => {
+    expect(truncateByWords("a b", 5)).toBe("a b");
+  });
+
+  it("truncates long text", () => {
+    expect(truncateByWords("a b c d", 2)).toBe("a b…");
+  });
+});

--- a/apps/web/src/helpers/truncateUrl.test.ts
+++ b/apps/web/src/helpers/truncateUrl.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import truncateUrl from "./truncateUrl";
+
+describe("truncateUrl", () => {
+  it("returns stripped url for hey domain", () => {
+    expect(truncateUrl("https://www.hey.xyz/test", 10)).toBe("hey.xyz/test");
+  });
+
+  it("truncates long url", () => {
+    expect(truncateUrl("https://example.com/longpath", 10)).toBe("example.c…");
+  });
+
+  it("falls back for invalid url", () => {
+    expect(truncateUrl("not a url", 5)).toBe("not …");
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,8 @@
+import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     environment: "node"
   }


### PR DESCRIPTION
## Summary
- add vitest config alias support
- add extensive unit tests for helper utilities

## Testing
- `pnpm --filter @hey/web exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6843de5370308330968e596c19c7a6e1