### PR TITLE
Refactor to eliminate `any` types

### DIFF
--- a/apps/api/src/utils/lensPg.ts
+++ b/apps/api/src/utils/lensPg.ts
@@ -13,7 +13,7 @@ interface InitializeDbResult {
   pg: IMain<unknown, pg.IClient>;
 }
 
-type DatabaseParams = null | Record<string, any>;
+type DatabaseParams = null | Record<string, unknown>;
 type DatabaseQuery = string;
 
 class Database {
@@ -42,8 +42,9 @@ class Database {
     connectionParameters: IConnectionParameters
   ): InitializeDbResult {
     const pgp = pgPromise({
-      error: (error: any) => {
-        const errorMessage = error.message || error;
+      error: (error: unknown) => {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
         console.error(`LENS POSTGRES ERROR WITH TRACE: ${errorMessage}`);
       }
     });
@@ -57,14 +58,14 @@ class Database {
   public multi(
     query: DatabaseQuery,
     params: DatabaseParams = null
-  ): Promise<any[][]> {
+  ): Promise<unknown[][]> {
     return this._readDb.multi(query, params);
   }
 
   public query(
     query: DatabaseQuery,
     params: DatabaseParams = null
-  ): Promise<any[]> {
+  ): Promise<unknown[]> {
     return this._readDb.query(query, params);
   }
 }

--- a/apps/api/src/utils/redis.ts
+++ b/apps/api/src/utils/redis.ts
@@ -52,7 +52,7 @@ export const generateExtraLongExpiry = (): number => {
 
 export const setRedis = async (
   key: string,
-  value: boolean | number | Record<string, any> | string,
+  value: boolean | number | string | Record<string, unknown> | unknown[],
   expiry = generateSmallExpiry()
 ) => {
   if (!redisClient) {

--- a/apps/web/src/components/Account/FollowersYouKnowOverview.tsx
+++ b/apps/web/src/components/Account/FollowersYouKnowOverview.tsx
@@ -39,7 +39,7 @@ const FollowersYouKnowOverview = ({
 
   const renderAccountNames = () => {
     const names = accounts.map(
-      (account) => getAccount(account.follower as any).name
+      (account) => getAccount(account.follower as Follower).name
     );
     const count = names.length - 3;
 

--- a/apps/web/src/components/Composer/ChooseThumbnail.tsx
+++ b/apps/web/src/components/Composer/ChooseThumbnail.tsx
@@ -48,7 +48,7 @@ const ChooseThumbnail = () => {
       getFileFromDataURL(
         thumbnails[index].blobUrl,
         "thumbnail.jpeg",
-        async (file: any) => {
+        async (file: File | null) => {
           if (!file) {
             return toast.error("Please upload a custom thumbnail");
           }

--- a/apps/web/src/components/Composer/LicensePicker.tsx
+++ b/apps/web/src/components/Composer/LicensePicker.tsx
@@ -7,13 +7,17 @@ import { Link } from "react-router";
 const LicensePicker = () => {
   const { license, setLicense } = usePostLicenseStore();
 
-  const otherOptions = Object.values(MetadataLicenseType)
+  const otherOptions: {
+    label: string;
+    selected: boolean;
+    value: MetadataLicenseType;
+  }[] = Object.values(MetadataLicenseType)
     .filter((type) => getAssetLicense(type))
     .map((type) => ({
       label: getAssetLicense(type)?.label as string,
       selected: license === type,
       value: type
-    })) as any;
+    }));
 
   const options = [
     {

--- a/apps/web/src/components/Composer/NewAttachments.tsx
+++ b/apps/web/src/components/Composer/NewAttachments.tsx
@@ -48,10 +48,10 @@ const NewAttachments = ({
     }
   }, [videoRef, attachments]);
 
-  const handleRemoveAttachment = (attachment: any) => {
+  const handleRemoveAttachment = (attachment: NewAttachment) => {
     const arr = attachments;
     setAttachments(
-      arr.filter((element: any) => {
+      arr.filter((element: NewAttachment) => {
         return element !== attachment;
       })
     );

--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -112,7 +112,7 @@ const NewPublication = ({ className, post, feed }: NewPublicationProps) => {
     reset();
   };
 
-  const onError = (error?: any) => {
+  const onError = (error?: unknown) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Post/Actions/Share/UndoRepost.tsx
+++ b/apps/web/src/components/Post/Actions/Share/UndoRepost.tsx
@@ -42,7 +42,7 @@ const UndoRepost = ({
     toast.success("Undone repost");
   };
 
-  const onError = (error?: any) => {
+  const onError = (error?: unknown) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Post/OpenAction/CollectAction/CollectActionButton.tsx
+++ b/apps/web/src/components/Post/OpenAction/CollectAction/CollectActionButton.tsx
@@ -30,7 +30,7 @@ const CollectActionButton = ({
   postAction,
   post
 }: CollectActionButtonProps) => {
-  const collectAction = getCollectActionData(postAction as any);
+  const collectAction = getCollectActionData(postAction);
   const { currentAccount } = useAccountStore();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [hasSimpleCollected, setHasSimpleCollected] = useState(
@@ -42,7 +42,7 @@ const CollectActionButton = ({
   const endTimestamp = collectAction?.endsAt;
   const collectLimit = collectAction?.collectLimit;
   const amount = collectAction?.price as number;
-  const assetAddress = collectAction?.assetAddress as any;
+  const assetAddress = collectAction?.assetAddress as string | undefined;
   const assetSymbol = collectAction?.assetSymbol as string;
   const isAllCollected = collectLimit ? collects >= collectLimit : false;
   const isSaleEnded = endTimestamp

--- a/apps/web/src/components/Settings/Personalize/Form.tsx
+++ b/apps/web/src/components/Settings/Personalize/Form.tsx
@@ -133,7 +133,9 @@ const PersonalizeSettingsForm = () => {
         )
         .map(({ key, type, value }) => ({
           key,
-          type: MetadataAttributeType[type] as any,
+          type: MetadataAttributeType[
+            type as keyof typeof MetadataAttributeType
+          ],
           value
         })) || [];
 

--- a/apps/web/src/components/Shared/Account/SwitchAccounts.tsx
+++ b/apps/web/src/components/Shared/Account/SwitchAccounts.tsx
@@ -23,7 +23,7 @@ const SwitchAccounts = () => {
   );
   const { address } = useAccount();
 
-  const onError = (error?: any) => {
+  const onError = (error?: unknown) => {
     setIsSubmitting(false);
     setLoggingInAccountId(null);
     errorToast(error);

--- a/apps/web/src/components/Shared/Auth/Login.tsx
+++ b/apps/web/src/components/Shared/Auth/Login.tsx
@@ -33,7 +33,7 @@ const Login = ({ setHasAccounts }: LoginProps) => {
   );
   const [isExpanded, setIsExpanded] = useState(true);
 
-  const onError = (error?: any) => {
+  const onError = (error?: unknown) => {
     setIsSubmitting(false);
     setLoggingInAccountId(null);
     errorToast(error);

--- a/apps/web/src/components/Shared/Auth/Signup/ChooseUsername.tsx
+++ b/apps/web/src/components/Shared/Auth/Signup/ChooseUsername.tsx
@@ -56,7 +56,7 @@ const ChooseUsername = () => {
   const handleWrongNetwork = useHandleWrongNetwork();
   const form = useZodForm({ mode: "onChange", schema: ValidationSchema });
 
-  const onError = (error?: any) => {
+  const onError = (error?: unknown) => {
     setIsSubmitting(false);
     errorToast(error);
   };

--- a/apps/web/src/components/Shared/Auth/WalletSelector.tsx
+++ b/apps/web/src/components/Shared/Auth/WalletSelector.tsx
@@ -18,7 +18,7 @@ const WalletSelector: FC = () => {
   ];
 
   const filteredConnectors = connectors
-    .filter((connector: any) => allowedConnectors.includes(connector.id))
+    .filter((connector) => allowedConnectors.includes(connector.id))
     .sort(
       (a: Connector, b: Connector) =>
         allowedConnectors.indexOf(a.id) - allowedConnectors.indexOf(b.id)
@@ -43,7 +43,7 @@ const WalletSelector: FC = () => {
     </div>
   ) : (
     <div className="inline-block w-full space-y-3 overflow-hidden text-left align-middle">
-      {filteredConnectors.map((connector: any) => {
+      {filteredConnectors.map((connector) => {
         return (
           <button
             className={cn(

--- a/apps/web/src/components/Shared/Markup/Code.tsx
+++ b/apps/web/src/components/Shared/Markup/Code.tsx
@@ -1,4 +1,6 @@
-const Code = (props: any) => {
+import type { HTMLProps } from "react";
+
+const Code = (props: HTMLProps<HTMLElement>) => {
   return (
     <code
       className="rounded-lg bg-gray-300 px-[5px] py-[2px] text-sm dark:bg-gray-700"

--- a/apps/web/src/components/Shared/Markup/index.tsx
+++ b/apps/web/src/components/Shared/Markup/index.tsx
@@ -30,7 +30,7 @@ const Markup = ({ children, className = "", mentions = [] }: MarkupProps) => {
   }
 
   const components = {
-    a: (props: any) => {
+    a: (props: React.HTMLProps<HTMLAnchorElement>) => {
       return <MarkupLink mentions={mentions} title={props.title} />;
     },
     code: Code

--- a/apps/web/src/components/Shared/Post/Attachments.tsx
+++ b/apps/web/src/components/Shared/Post/Attachments.tsx
@@ -102,9 +102,7 @@ const Attachments = ({ asset, attachments }: AttachmentsProps) => {
       )}
       {displayDecision === "displayVideoAsset" && (
         <Video
-          src={
-            getSrc(asset?.uri) || [{ src: asset?.uri, type: "video" } as any]
-          }
+          src={getSrc(asset?.uri) || [{ src: asset?.uri, type: "video" }]}
           poster={asset?.cover as string}
         />
       )}

--- a/apps/web/src/components/Shared/UI/ErrorMessage.tsx
+++ b/apps/web/src/components/Shared/UI/ErrorMessage.tsx
@@ -4,7 +4,7 @@ import { H6 } from "./Typography";
 
 interface ErrorMessageProps {
   className?: string;
-  error?: any;
+  error?: unknown;
   title?: string;
 }
 

--- a/apps/web/src/components/Shared/UI/Select.tsx
+++ b/apps/web/src/components/Shared/UI/Select.tsx
@@ -15,7 +15,7 @@ interface SelectProps {
   className?: string;
   defaultValue?: string;
   iconClassName?: string;
-  onChange: (value: any) => any;
+  onChange: (value: string | number) => void;
   options?: {
     disabled?: boolean;
     helper?: string;

--- a/apps/web/src/helpers/stopEventPropagation.ts
+++ b/apps/web/src/helpers/stopEventPropagation.ts
@@ -1,3 +1,5 @@
-const stopEventPropagation = (event: any) => event.stopPropagation();
+import type { SyntheticEvent } from "react";
+
+const stopEventPropagation = (event: SyntheticEvent) => event.stopPropagation();
 
 export default stopEventPropagation;

--- a/apps/web/src/helpers/uploadMetadata.ts
+++ b/apps/web/src/helpers/uploadMetadata.ts
@@ -3,7 +3,9 @@ import { Errors } from "@hey/data/errors";
 import { immutable } from "@lens-chain/storage-client";
 import { storageClient } from "./storageClient";
 
-const uploadMetadata = async (data: any): Promise<string> => {
+const uploadMetadata = async (
+  data: Record<string, unknown>
+): Promise<string> => {
   try {
     const { uri } = await storageClient.uploadAsJson(data, {
       acl: immutable(CHAIN.id)

--- a/apps/web/src/hooks/usePostMetadata.tsx
+++ b/apps/web/src/hooks/usePostMetadata.tsx
@@ -14,7 +14,7 @@ import { useCallback } from "react";
 import { usePostAudioStore } from "../store/non-persisted/post/usePostAudioStore";
 
 interface UsePostMetadataProps {
-  baseMetadata: any;
+  baseMetadata: Record<string, unknown>;
 }
 
 const usePostMetadata = () => {

--- a/apps/web/src/hooks/useTransactionLifecycle.tsx
+++ b/apps/web/src/hooks/useTransactionLifecycle.tsx
@@ -1,6 +1,11 @@
 import { Errors } from "@hey/data/errors";
 import selfFundedTransactionData from "@hey/helpers/selfFundedTransactionData";
 import sponsoredTransactionData from "@hey/helpers/sponsoredTransactionData";
+import type {
+  SelfFundedTransactionRequestFragment,
+  SponsoredTransactionRequestFragment,
+  TransactionWillFailFragment
+} from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
 import { sendEip712Transaction, sendTransaction } from "viem/zksync";
 import { useWalletClient } from "wagmi";
@@ -11,7 +16,7 @@ const useTransactionLifecycle = () => {
   const handleWrongNetwork = useHandleWrongNetwork();
 
   const handleSponsoredTransaction = async (
-    transactionData: any,
+    transactionData: SponsoredTransactionRequestFragment,
     onCompleted: (hash: string) => void
   ) => {
     await handleWrongNetwork();
@@ -25,7 +30,7 @@ const useTransactionLifecycle = () => {
   };
 
   const handleSelfFundedTransaction = async (
-    transactionData: any,
+    transactionData: SelfFundedTransactionRequestFragment,
     onCompleted: (hash: string) => void
   ) => {
     await handleWrongNetwork();
@@ -43,7 +48,10 @@ const useTransactionLifecycle = () => {
     onCompleted,
     onError
   }: {
-    transactionData: any;
+    transactionData:
+      | SponsoredTransactionRequestFragment
+      | SelfFundedTransactionRequestFragment
+      | TransactionWillFailFragment;
     onCompleted: (hash: string) => void;
     onError: (error: ApolloClientError) => void;
   }) => {

--- a/packages/helpers/getAccount.test.ts
+++ b/packages/helpers/getAccount.test.ts
@@ -1,4 +1,5 @@
 import { LENS_NAMESPACE, NULL_ADDRESS } from "@hey/data/constants";
+import type { AccountFragment } from "@hey/indexer";
 import { describe, expect, it } from "vitest";
 import formatAddress from "./formatAddress";
 import getAccount from "./getAccount";
@@ -25,7 +26,7 @@ describe("getAccount", () => {
 
   it("returns deleted account", () => {
     const account: Account = { owner: NULL_ADDRESS, address };
-    expect(getAccount(account as any)).toEqual({
+    expect(getAccount(account as unknown as AccountFragment)).toEqual({
       name: "Deleted Account",
       link: "",
       username: "deleted",
@@ -40,7 +41,7 @@ describe("getAccount", () => {
       metadata: { name: "Alice✓" },
       username: { value: `${LENS_NAMESPACE}alice`, localName: "alice" }
     };
-    expect(getAccount(account as any)).toEqual({
+    expect(getAccount(account as unknown as AccountFragment)).toEqual({
       name: "Alice",
       link: "/u/alice",
       username: "alice",
@@ -51,7 +52,7 @@ describe("getAccount", () => {
   it("uses address when username missing", () => {
     const account: Account = { owner: "0x1", address };
     const formatted = formatAddress(address);
-    expect(getAccount(account as any)).toEqual({
+    expect(getAccount(account as unknown as AccountFragment)).toEqual({
       name: formatted,
       link: `/account/${address}`,
       username: formatted,

--- a/packages/helpers/getAttachmentsData.test.ts
+++ b/packages/helpers/getAttachmentsData.test.ts
@@ -1,3 +1,4 @@
+import type { AnyMediaFragment } from "@hey/indexer";
 import { describe, expect, it } from "vitest";
 import getAttachmentsData from "./getAttachmentsData";
 import sanitizeDStorageUrl from "./sanitizeDStorageUrl";
@@ -15,8 +16,8 @@ describe("getAttachmentsData", () => {
       { __typename: "MediaImage", item: ipfs },
       { __typename: "MediaVideo", item: ipfs, cover: ipfs },
       { __typename: "MediaAudio", item: ipfs, cover: ipfs, artist: "a" }
-    ];
-    expect(getAttachmentsData(attachments as any)).toEqual([
+    ] as unknown as AnyMediaFragment[];
+    expect(getAttachmentsData(attachments)).toEqual([
       { type: "Image", uri: sanitized },
       { type: "Video", uri: sanitized, coverUri: sanitized },
       { type: "Audio", uri: sanitized, coverUri: sanitized, artist: "a" }

--- a/packages/helpers/getAttachmentsData.ts
+++ b/packages/helpers/getAttachmentsData.ts
@@ -1,35 +1,46 @@
 import type { AnyMediaFragment, Maybe } from "@hey/indexer";
 import sanitizeDStorageUrl from "./sanitizeDStorageUrl";
 
-const getAttachmentsData = (attachments?: Maybe<AnyMediaFragment[]>): any => {
+export interface AttachmentData {
+  type: "Audio" | "Image" | "Video";
+  uri: string;
+  artist?: string;
+  coverUri?: string;
+}
+
+const getAttachmentsData = (
+  attachments?: Maybe<AnyMediaFragment[]>
+): AttachmentData[] => {
   if (!attachments) {
     return [];
   }
 
-  return attachments.map((attachment) => {
-    switch (attachment.__typename) {
-      case "MediaImage":
-        return {
-          type: "Image",
-          uri: sanitizeDStorageUrl(attachment.item)
-        };
-      case "MediaVideo":
-        return {
-          coverUri: sanitizeDStorageUrl(attachment.cover),
-          type: "Video",
-          uri: sanitizeDStorageUrl(attachment.item)
-        };
-      case "MediaAudio":
-        return {
-          artist: attachment.artist,
-          coverUri: sanitizeDStorageUrl(attachment.cover),
-          type: "Audio",
-          uri: sanitizeDStorageUrl(attachment.item)
-        };
-      default:
-        return [];
-    }
-  });
+  return attachments
+    .map((attachment) => {
+      switch (attachment.__typename) {
+        case "MediaImage":
+          return {
+            type: "Image",
+            uri: sanitizeDStorageUrl(attachment.item)
+          };
+        case "MediaVideo":
+          return {
+            coverUri: sanitizeDStorageUrl(attachment.cover),
+            type: "Video",
+            uri: sanitizeDStorageUrl(attachment.item)
+          };
+        case "MediaAudio":
+          return {
+            artist: attachment.artist,
+            coverUri: sanitizeDStorageUrl(attachment.cover),
+            type: "Audio",
+            uri: sanitizeDStorageUrl(attachment.item)
+          };
+        default:
+          return null;
+      }
+    })
+    .filter(Boolean) as AttachmentData[];
 };
 
 export default getAttachmentsData;

--- a/packages/helpers/getAvatar.test.ts
+++ b/packages/helpers/getAvatar.test.ts
@@ -10,7 +10,7 @@ const ipfs = "ipfs://avatarHash";
 
 describe("getAvatar", () => {
   it("returns default when entity missing", () => {
-    expect(getAvatar(undefined as any)).toBe(DEFAULT_AVATAR);
+    expect(getAvatar(undefined)).toBe(DEFAULT_AVATAR);
   });
 
   it("sanitizes ipfs avatar", () => {

--- a/packages/helpers/getAvatar.ts
+++ b/packages/helpers/getAvatar.ts
@@ -2,8 +2,17 @@ import { DEFAULT_AVATAR, TRANSFORMS } from "@hey/data/constants";
 import imageKit from "./imageKit";
 import sanitizeDStorageUrl from "./sanitizeDStorageUrl";
 
+interface AvatarMetadata {
+  icon?: string | null;
+  picture?: string | null;
+}
+
+interface AvatarEntity {
+  metadata?: AvatarMetadata | null;
+}
+
 const getAvatar = (
-  entity: any,
+  entity?: AvatarEntity | null,
   namedTransform = TRANSFORMS.AVATAR_SMALL
 ): string => {
   if (!entity) {

--- a/packages/helpers/getPostData.test.ts
+++ b/packages/helpers/getPostData.test.ts
@@ -1,4 +1,5 @@
 import { PLACEHOLDER_IMAGE } from "@hey/data/constants";
+import type { PostMetadataFragment } from "@hey/indexer";
 import { describe, expect, it } from "vitest";
 import getPostData from "./getPostData";
 import sanitizeDStorageUrl from "./sanitizeDStorageUrl";
@@ -8,7 +9,10 @@ const sanitized = sanitizeDStorageUrl(ipfs);
 
 describe("getPostData", () => {
   it("handles text-only metadata", () => {
-    const meta = { __typename: "TextOnlyMetadata", content: "hi" } as any;
+    const meta = {
+      __typename: "TextOnlyMetadata",
+      content: "hi"
+    } as unknown as PostMetadataFragment;
     expect(getPostData(meta)).toEqual({ content: "hi" });
   });
 
@@ -18,7 +22,7 @@ describe("getPostData", () => {
       content: "img",
       image: { item: ipfs },
       attachments: [{ __typename: "MediaImage", item: ipfs }]
-    } as any;
+    } as unknown as PostMetadataFragment;
     expect(getPostData(meta)).toEqual({
       asset: { type: "Image", uri: sanitized },
       attachments: [{ type: "Image", uri: sanitized }],
@@ -33,7 +37,7 @@ describe("getPostData", () => {
       title: undefined,
       audio: { item: ipfs, cover: undefined, artist: undefined },
       attachments: []
-    } as any;
+    } as unknown as PostMetadataFragment;
     expect(getPostData(meta)).toEqual({
       asset: {
         artist: undefined,
@@ -47,6 +51,8 @@ describe("getPostData", () => {
   });
 
   it("returns null for unknown type", () => {
-    expect(getPostData({ __typename: "Unknown" } as any)).toBeNull();
+    expect(
+      getPostData({ __typename: "Unknown" } as unknown as PostMetadataFragment)
+    ).toBeNull();
   });
 });

--- a/packages/helpers/isAccountDeleted.test.ts
+++ b/packages/helpers/isAccountDeleted.test.ts
@@ -1,12 +1,17 @@
 import { NULL_ADDRESS } from "@hey/data/constants";
+import type { AccountFragment } from "@hey/indexer";
 import { describe, expect, it } from "vitest";
 import isAccountDeleted from "./isAccountDeleted";
 
 describe("isAccountDeleted", () => {
   it("returns true when owner is null address", () => {
-    expect(isAccountDeleted({ owner: NULL_ADDRESS } as any)).toBe(true);
+    expect(
+      isAccountDeleted({ owner: NULL_ADDRESS } as unknown as AccountFragment)
+    ).toBe(true);
   });
   it("returns false otherwise", () => {
-    expect(isAccountDeleted({ owner: "0x1" } as any)).toBe(false);
+    expect(
+      isAccountDeleted({ owner: "0x1" } as unknown as AccountFragment)
+    ).toBe(false);
   });
 });

--- a/packages/helpers/postHelpers.test.ts
+++ b/packages/helpers/postHelpers.test.ts
@@ -1,11 +1,16 @@
+import type { AnyPostFragment } from "@hey/indexer";
 import { describe, expect, it } from "vitest";
 import { isRepost } from "./postHelpers";
 
 describe("isRepost", () => {
   it("detects repost", () => {
-    expect(isRepost({ __typename: "Repost" } as any)).toBe(true);
+    expect(
+      isRepost({ __typename: "Repost" } as unknown as AnyPostFragment)
+    ).toBe(true);
   });
   it("returns false otherwise", () => {
-    expect(isRepost({ __typename: "Post" } as any)).toBe(false);
+    expect(isRepost({ __typename: "Post" } as unknown as AnyPostFragment)).toBe(
+      false
+    );
   });
 });

--- a/packages/helpers/selfFundedTransactionData.test.ts
+++ b/packages/helpers/selfFundedTransactionData.test.ts
@@ -1,3 +1,4 @@
+import type { Eip1559TransactionRequest } from "@hey/indexer";
 import { describe, expect, it } from "vitest";
 import selfFundedTransactionData from "./selfFundedTransactionData";
 
@@ -11,7 +12,7 @@ describe("selfFundedTransactionData", () => {
       nonce: 4,
       to: "0x1",
       value: 5
-    } as any;
+    } as unknown as Eip1559TransactionRequest;
     expect(selfFundedTransactionData(raw)).toEqual({
       data: "0x",
       gas: 1n,

--- a/packages/helpers/sponsoredTransactionData.test.ts
+++ b/packages/helpers/sponsoredTransactionData.test.ts
@@ -1,3 +1,4 @@
+import type { Eip712TransactionRequest } from "@hey/indexer";
 import { describe, expect, it } from "vitest";
 import sponsoredTransactionData from "./sponsoredTransactionData";
 
@@ -14,7 +15,7 @@ describe("sponsoredTransactionData", () => {
       customData: {
         paymasterParams: { paymaster: "p", paymasterInput: "i" }
       }
-    } as any;
+    } as unknown as Eip712TransactionRequest;
     expect(sponsoredTransactionData(raw)).toEqual({
       data: "0x",
       gas: 1n,


### PR DESCRIPTION
## Summary
- add typed interfaces for avatars and attachments
- remove `any` from tests and helper function signatures
- clean up event utilities and various components
- tweak database utils

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6843dd6fbb8c833089e65718cc11635c