### PR TITLE
Setup vitest for API utils

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,8 @@
     "prisma:format": "prisma format --schema ./src/prisma/schema.prisma",
     "prisma:migrate": "prisma migrate dev --schema ./src/prisma/schema.prisma",
     "start": "tsx watch src/index.ts",
-    "typecheck": "tsc --pretty"
+    "typecheck": "tsc --pretty",
+    "test": "vitest"
   },
   "dependencies": {
     "@aws-sdk/client-sts": "^3.826.0",
@@ -42,6 +43,7 @@
     "@hey/config": "workspace:*",
     "@types/node": "^22.15.30",
     "prisma": "^6.9.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.2"
   }
 }

--- a/apps/api/src/routes/ai/translate.ts
+++ b/apps/api/src/routes/ai/translate.ts
@@ -19,14 +19,14 @@ const translate = async (ctx: Context) => {
       return ctx.json({ success: true, data: { text: cachedData } });
     }
 
-    const metadata = await lensPg.query(
+    const metadata = (await lensPg.query(
       `
         SELECT content, language
         FROM post.metadata
         WHERE post = $1;
       `,
       [getDbPostId(post)]
-    );
+    )) as Array<{ content?: string }>;
 
     const text = metadata[0]?.content;
 

--- a/apps/api/src/routes/cron/guild/syncFollowersStandingToGuild.ts
+++ b/apps/api/src/routes/cron/guild/syncFollowersStandingToGuild.ts
@@ -6,13 +6,13 @@ import syncAddressesToGuild from "src/utils/syncAddressesToGuild";
 // Sync followers standing of accounts with 1000+ followers
 const syncFollowersStandingToGuild = async (ctx: Context) => {
   try {
-    const accounts = await lensPg.query(
+    const accounts = (await lensPg.query(
       `
         SELECT account
         FROM account.follower_summary
         WHERE total_followers >= 1000;
       `
-    );
+    )) as Array<{ account: Buffer }>;
 
     const addresses = accounts.map((account) =>
       `0x${account.account.toString("hex")}`.toLowerCase()

--- a/apps/api/src/routes/cron/guild/syncHQScoreAccountsToGuild.ts
+++ b/apps/api/src/routes/cron/guild/syncHQScoreAccountsToGuild.ts
@@ -6,13 +6,13 @@ import syncAddressesToGuild from "src/utils/syncAddressesToGuild";
 // Sync accounts with score > 90
 const syncHQScoreAccountsToGuild = async (ctx: Context) => {
   try {
-    const accounts = await lensPg.query(
+    const accounts = (await lensPg.query(
       `
-        SELECT DISTINCT account 
+        SELECT DISTINCT account
         FROM ml.account_score
         WHERE score > 90;
       `
-    );
+    )) as Array<{ account: Buffer }>;
 
     const addresses = accounts.map((account) =>
       `0x${account.account.toString("hex")}`.toLowerCase()

--- a/apps/api/src/routes/cron/guild/syncSubscribersToGuild.ts
+++ b/apps/api/src/routes/cron/guild/syncSubscribersToGuild.ts
@@ -7,14 +7,14 @@ import syncAddressesToGuild from "src/utils/syncAddressesToGuild";
 // Sync accounts that has current subscriber status
 const syncSubscribersToGuild = async (ctx: Context) => {
   try {
-    const accounts = await lensPg.query(
+    const accounts = (await lensPg.query(
       `
         SELECT account
         FROM "group"."member"
         WHERE "group"::TEXT LIKE $1;
       `,
       [`%${PERMISSIONS.SUBSCRIPTION.replace("0x", "").toLowerCase()}%`]
-    );
+    )) as Array<{ account: Buffer }>;
 
     const addresses = accounts.map((account) =>
       `0x${account.account.toString("hex")}`.toLowerCase()

--- a/apps/api/src/routes/cron/removeExpiredSubscribers/index.ts
+++ b/apps/api/src/routes/cron/removeExpiredSubscribers/index.ts
@@ -7,7 +7,7 @@ import ABI from "./ABI";
 
 const removeExpiredSubscribers = async (ctx: Context) => {
   try {
-    const accounts = await lensPg.query(
+    const accounts = (await lensPg.query(
       `
         SELECT account
         FROM "group"."member"
@@ -16,7 +16,7 @@ const removeExpiredSubscribers = async (ctx: Context) => {
         LIMIT 1000;
       `,
       [`\\x${PERMISSIONS.SUBSCRIPTION.replace("0x", "").toLowerCase()}`]
-    );
+    )) as Array<{ account: Buffer }>;
 
     const addresses = accounts.map((account) =>
       `0x${account.account.toString("hex")}`.toLowerCase()

--- a/apps/api/src/routes/sitemap/accounts/accountSitemap.ts
+++ b/apps/api/src/routes/sitemap/accounts/accountSitemap.ts
@@ -39,7 +39,7 @@ const accountSitemap = async (ctx: Context) => {
           .up();
       }
     } else {
-      const dbUsernames = await lensPg.query(
+      const dbUsernames = (await lensPg.query(
         `
           SELECT local_name
           FROM account.username_assigned
@@ -48,7 +48,7 @@ const accountSitemap = async (ctx: Context) => {
           LIMIT $2;
         `,
         [(Number(batch) - 1) * SITEMAP_BATCH_SIZE, SITEMAP_BATCH_SIZE]
-      );
+      )) as Array<{ local_name: string }>;
 
       const usernamesToCache: string[] = [];
       for (const { local_name } of dbUsernames) {

--- a/apps/api/src/routes/sitemap/accounts/accountsSitemapIndex.ts
+++ b/apps/api/src/routes/sitemap/accounts/accountsSitemapIndex.ts
@@ -14,13 +14,13 @@ const accountsSitemapIndex = async (ctx: Context) => {
     if (cachedData) {
       totalUsernames = Number(cachedData);
     } else {
-      const usernames = await lensPg.query(
+      const usernames = (await lensPg.query(
         `
           SELECT CEIL(COUNT(*) / $1) AS count
           FROM account.username_assigned;
         `,
         [SITEMAP_BATCH_SIZE]
-      );
+      )) as Array<{ count: number }>;
 
       totalUsernames = Number(usernames[0]?.count) || 0;
       await setRedis(cacheKey, totalUsernames, hoursToSeconds(50 * 24));

--- a/apps/api/src/utils/constants.test.ts
+++ b/apps/api/src/utils/constants.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import {
+  CACHE_AGE_1_DAY,
+  HEY_USER_AGENT,
+  SITEMAP_BATCH_SIZE
+} from "./constants";
+
+describe("constants", () => {
+  it("have expected values", () => {
+    expect(HEY_USER_AGENT).toBe("HeyBot (like TwitterBot)");
+    expect(SITEMAP_BATCH_SIZE).toBe(25000);
+    expect(CACHE_AGE_1_DAY).toBe("public, s-maxage=86400, max-age=86400");
+  });
+});

--- a/apps/api/src/utils/defaultMetadata.test.ts
+++ b/apps/api/src/utils/defaultMetadata.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import defaultMetadata from "./defaultMetadata";
+
+describe("defaultMetadata", () => {
+  it("contains Hey title", () => {
+    expect(String(defaultMetadata)).toContain("<title>Hey</title>");
+  });
+});

--- a/apps/api/src/utils/getDbPostId.test.ts
+++ b/apps/api/src/utils/getDbPostId.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import getDbPostId from "./getDbPostId";
+
+describe("getDbPostId", () => {
+  it("converts decimal to hex prefix", () => {
+    expect(getDbPostId("123456")).toBe("\\x1e240");
+  });
+});

--- a/apps/api/src/utils/lensPg.test.ts
+++ b/apps/api/src/utils/lensPg.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+// biome-ignore lint/style/noVar: mock variables initialized before imports
+var queryMock: ReturnType<typeof vi.fn>;
+// biome-ignore lint/style/noVar: mock variables initialized before imports
+var multiMock: ReturnType<typeof vi.fn>;
+
+vi.mock("pg-promise", () => {
+  queryMock = vi.fn();
+  multiMock = vi.fn();
+  return {
+    default: () => {
+      const pgp = () => ({ query: queryMock, multi: multiMock });
+      pgp.helpers = {} as unknown;
+      pgp.as = {} as unknown;
+      return pgp;
+    }
+  };
+});
+
+import db from "./lensPg";
+
+describe("lensPg", () => {
+  it("calls query", async () => {
+    await db.query("SELECT 1");
+    expect(queryMock).toHaveBeenCalledWith("SELECT 1", null);
+  });
+
+  it("calls multi", async () => {
+    await db.multi("SELECT 1");
+    expect(multiMock).toHaveBeenCalledWith("SELECT 1", null);
+  });
+});

--- a/apps/api/src/utils/lensPg.ts
+++ b/apps/api/src/utils/lensPg.ts
@@ -13,7 +13,7 @@ interface InitializeDbResult {
   pg: IMain<unknown, pg.IClient>;
 }
 
-type DatabaseParams = null | Record<string, unknown>;
+type DatabaseParams = null | unknown[] | Record<string, unknown>;
 type DatabaseQuery = string;
 
 class Database {

--- a/apps/api/src/utils/openRouter.test.ts
+++ b/apps/api/src/utils/openRouter.test.ts
@@ -1,0 +1,14 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+let openRouter: typeof import("./openRouter").default;
+
+beforeAll(async () => {
+  process.env.OPENROUTER_API_KEY = "test";
+  openRouter = (await import("./openRouter")).default;
+});
+
+describe("openRouter", () => {
+  it("uses OpenRouter base URL", () => {
+    expect(openRouter.baseURL).toBe("https://openrouter.ai/api/v1");
+  });
+});

--- a/apps/api/src/utils/redis.test.ts
+++ b/apps/api/src/utils/redis.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateExtraLongExpiry,
+  generateSmallExpiry,
+  hoursToSeconds
+} from "./redis";
+
+describe("redis utils", () => {
+  it("converts hours to seconds", () => {
+    expect(hoursToSeconds(1)).toBe(3600);
+  });
+
+  it("generates small expiry within range", () => {
+    const value = generateSmallExpiry();
+    expect(value).toBeGreaterThanOrEqual(hoursToSeconds(24));
+    expect(value).toBeLessThanOrEqual(hoursToSeconds(48));
+  });
+
+  it("generates extra long expiry within range", () => {
+    const value = generateExtraLongExpiry();
+    expect(value).toBeGreaterThanOrEqual(hoursToSeconds(8 * 24));
+    expect(value).toBeLessThanOrEqual(hoursToSeconds(10 * 24));
+  });
+});

--- a/apps/api/src/utils/sha256.test.ts
+++ b/apps/api/src/utils/sha256.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import sha256 from "./sha256";
+
+describe("sha256", () => {
+  it("hashes text correctly", () => {
+    expect(sha256("hello")).toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    );
+  });
+});

--- a/apps/api/src/utils/signer.test.ts
+++ b/apps/api/src/utils/signer.test.ts
@@ -1,0 +1,18 @@
+import { privateKeyToAccount } from "viem/accounts";
+import { beforeAll, describe, expect, it } from "vitest";
+
+let signer: typeof import("./signer").default;
+
+beforeAll(async () => {
+  process.env.PRIVATE_KEY = `0x${"1".repeat(64)}`;
+  signer = (await import("./signer")).default;
+});
+
+describe("signer", () => {
+  it("creates wallet client with given key", () => {
+    const account = privateKeyToAccount(
+      process.env.PRIVATE_KEY as `0x${string}`
+    );
+    expect(signer.account.address).toBe(account.address);
+  });
+});

--- a/apps/api/src/utils/syncAddressesToGuild.test.ts
+++ b/apps/api/src/utils/syncAddressesToGuild.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+// biome-ignore lint/style/noVar: mock variable initialized before imports
+var updateMock: ReturnType<typeof vi.fn>;
+
+vi.mock("@guildxyz/sdk", () => {
+  updateMock = vi.fn(async () => ({ updatedAt: "now" }));
+  return {
+    createSigner: { custom: vi.fn((fn) => fn) },
+    createGuildClient: vi.fn(() => ({
+      guild: { role: { requirement: { update: updateMock } } }
+    }))
+  };
+});
+
+vi.mock("./signer", () => ({
+  default: { signMessage: vi.fn(), account: { address: "0xabc" } }
+}));
+
+import syncAddressesToGuild from "./syncAddressesToGuild";
+
+describe("syncAddressesToGuild", () => {
+  it("updates addresses", async () => {
+    const result = await syncAddressesToGuild({
+      addresses: ["0x1"],
+      requirementId: 1,
+      roleId: 2
+    });
+
+    expect(updateMock).toHaveBeenCalled();
+    expect(result).toEqual({ success: true, total: 1, updatedAt: "now" });
+  });
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node"
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.2.2
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
 
   apps/web:
     dependencies:


### PR DESCRIPTION
## Summary
- configure vitest for `apps/api`
- add unit tests for API utilities
- widen `lensPg` query parameter type to allow arrays
- typecast database query results to satisfy the type checker

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6843f2574ff88330ad231b6f737c83b4