### PR TITLE
Add helper edge case tests

### DIFF
--- a/packages/helpers/getAvatar.test.ts
+++ b/packages/helpers/getAvatar.test.ts
@@ -13,6 +13,16 @@ describe("getAvatar", () => {
     expect(getAvatar(undefined)).toBe(DEFAULT_AVATAR);
   });
 
+  it("uses icon when picture missing", () => {
+    const icon = "ipfs://iconHash";
+    const avatar = getAvatar({ metadata: { picture: null, icon } });
+    expect(avatar).toContain("iconHash");
+  });
+
+  it("falls back to default when both missing", () => {
+    expect(getAvatar({ metadata: {} })).toBe(DEFAULT_AVATAR);
+  });
+
   it("sanitizes ipfs avatar", () => {
     const avatar = getAvatar({ metadata: { picture: ipfs } });
     expect(avatar).toContain("gw.ipfs-lens.dev/ipfs/avatarHash");

--- a/packages/helpers/parseJwt.test.ts
+++ b/packages/helpers/parseJwt.test.ts
@@ -17,4 +17,22 @@ describe("parseJwt", () => {
       act: { sub: "" }
     });
   });
+
+  it("handles token with missing sections", () => {
+    expect(parseJwt("onlytwo.sections")).toEqual({
+      sub: "",
+      exp: 0,
+      sid: "",
+      act: { sub: "" }
+    });
+  });
+
+  it("handles malformed base64", () => {
+    expect(parseJwt("a.!!!.b")).toEqual({
+      sub: "",
+      exp: 0,
+      sid: "",
+      act: { sub: "" }
+    });
+  });
 });

--- a/packages/helpers/sanitizeDStorageUrl.test.ts
+++ b/packages/helpers/sanitizeDStorageUrl.test.ts
@@ -18,6 +18,18 @@ describe("sanitizeDStorageUrl", () => {
     );
   });
 
+  it("converts ipfs://ipfs/", () => {
+    expect(sanitizeDStorageUrl(`ipfs://ipfs/${hash}`)).toBe(
+      `${IPFS_GATEWAY}/${hash}`
+    );
+  });
+
+  it("converts ipfs.io gateway", () => {
+    expect(sanitizeDStorageUrl(`https://ipfs.io/ipfs/${hash}`)).toBe(
+      `${IPFS_GATEWAY}/${hash}`
+    );
+  });
+
   it("converts lens://", () => {
     expect(sanitizeDStorageUrl(`lens://${hash}`)).toBe(
       `${STORAGE_NODE_URL}/${hash}`

--- a/packages/helpers/sponsoredTransactionData.test.ts
+++ b/packages/helpers/sponsoredTransactionData.test.ts
@@ -28,4 +28,28 @@ describe("sponsoredTransactionData", () => {
       value: 5n
     });
   });
+
+  it("omits paymaster fields when missing", () => {
+    const raw = {
+      data: "0x",
+      gasLimit: 1,
+      maxFeePerGas: 2,
+      maxPriorityFeePerGas: 3,
+      nonce: 4,
+      to: "0x1",
+      value: 5,
+      customData: {}
+    } as unknown as Eip712TransactionRequest;
+    expect(sponsoredTransactionData(raw)).toEqual({
+      data: "0x",
+      gas: 1n,
+      maxFeePerGas: 2n,
+      maxPriorityFeePerGas: 3n,
+      nonce: 4,
+      paymaster: undefined,
+      paymasterInput: undefined,
+      to: "0x1",
+      value: 5n
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- extend `sanitizeDStorageUrl` tests for extra IPFS formats
- verify `sponsoredTransactionData` when `paymasterParams` missing
- cover `getAvatar` fallbacks
- add more `parseJwt` error scenarios

## Testing
- `pnpm --filter @hey/helpers exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6843f36c402c8330ba6d437af6c1774d