### PR TITLE
Add ping route test

### DIFF
--- a/apps/api/src/routes/ping.test.ts
+++ b/apps/api/src/routes/ping.test.ts
@@ -1,0 +1,15 @@
+import type { Context } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import ping from "./ping";
+
+describe("ping route", () => {
+  it("returns pong", async () => {
+    const jsonMock = vi.fn((body: unknown) => body);
+    const ctx = { json: jsonMock } as unknown as Context;
+
+    const result = await ping(ctx);
+
+    expect(jsonMock).toHaveBeenCalledWith({ ping: "pong" });
+    expect(result).toEqual({ ping: "pong" });
+  });
+});


### PR DESCRIPTION
## Summary
- add test for ping route to demonstrate API route testing

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684436097c80833085d4cc91a80e6268