### PR TITLE
Add extensive tests for API routes

### DIFF
--- a/apps/api/src/routes/ai/translate.test.ts
+++ b/apps/api/src/routes/ai/translate.test.ts
@@ -1,0 +1,74 @@
+import type { Context } from "hono";
+import lensPg from "src/utils/lensPg";
+import openRouter from "src/utils/openRouter";
+import { getRedis, setRedis } from "src/utils/redis";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import translate from "./translate";
+
+vi.mock("src/utils/redis", () => ({
+  getRedis: vi.fn(),
+  setRedis: vi.fn(),
+  generateExtraLongExpiry: vi.fn(() => 10)
+}));
+vi.mock("src/utils/lensPg", () => ({ default: { query: vi.fn() } }));
+vi.mock("src/utils/openRouter", () => ({
+  default: { chat: { completions: { create: vi.fn() } } }
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ai translate route", () => {
+  it("returns cached translation when available", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "cached"
+    );
+    const json = vi.fn((b: unknown) => b);
+    const ctx = {
+      req: { json: vi.fn(async () => ({ post: "1" })) },
+      json
+    } as unknown as Context;
+
+    const result = await translate(ctx);
+
+    expect(json).toHaveBeenCalledWith({
+      success: true,
+      data: { text: "cached" }
+    });
+    expect(result).toEqual({ success: true, data: { text: "cached" } });
+    expect(lensPg.query).not.toHaveBeenCalled();
+    expect(
+      openRouter.chat.completions.create as unknown as ReturnType<typeof vi.fn>
+    ).not.toHaveBeenCalled();
+    expect(setRedis).not.toHaveBeenCalled();
+  });
+
+  it("looks up text, translates and caches when not cached", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (lensPg.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { content: "Hola" }
+    ]);
+    (
+      openRouter.chat.completions.create as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ choices: [{ message: { content: "Hello" } }] });
+    const json = vi.fn((b: unknown) => b);
+    const ctx = {
+      req: { json: vi.fn(async () => ({ post: "1" })) },
+      json
+    } as unknown as Context;
+
+    const result = await translate(ctx);
+
+    expect(lensPg.query).toHaveBeenCalled();
+    expect(
+      openRouter.chat.completions.create as unknown as ReturnType<typeof vi.fn>
+    ).toHaveBeenCalled();
+    expect(setRedis).toHaveBeenCalledWith("ai:translate:1", "Hello", 10);
+    expect(json).toHaveBeenCalledWith({
+      success: true,
+      data: { text: "Hello" }
+    });
+    expect(result).toEqual({ success: true, data: { text: "Hello" } });
+  });
+});

--- a/apps/api/src/routes/cron/guild/syncFollowersStandingToGuild.test.ts
+++ b/apps/api/src/routes/cron/guild/syncFollowersStandingToGuild.test.ts
@@ -1,0 +1,34 @@
+import type { Context } from "hono";
+import lensPg from "src/utils/lensPg";
+import syncAddressesToGuild from "src/utils/syncAddressesToGuild";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import syncFollowersStandingToGuild from "./syncFollowersStandingToGuild";
+
+vi.mock("src/utils/lensPg", () => ({ default: { query: vi.fn() } }));
+vi.mock("src/utils/syncAddressesToGuild", () => ({
+  default: vi.fn(async () => ({ success: true }))
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("syncFollowersStandingToGuild", () => {
+  it("queries db and syncs addresses", async () => {
+    const buf = Buffer.from("1".repeat(40), "hex");
+    (lensPg.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { account: buf }
+    ]);
+    const ctx = { json: vi.fn((b: unknown) => b) } as unknown as Context;
+
+    const result = await syncFollowersStandingToGuild(ctx);
+
+    expect(lensPg.query).toHaveBeenCalled();
+    expect(syncAddressesToGuild).toHaveBeenCalledWith({
+      addresses: [`0x${buf.toString("hex")}`],
+      roleId: 173474,
+      requirementId: 471279
+    });
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/apps/api/src/routes/cron/guild/syncHQScoreAccountsToGuild.test.ts
+++ b/apps/api/src/routes/cron/guild/syncHQScoreAccountsToGuild.test.ts
@@ -1,0 +1,34 @@
+import type { Context } from "hono";
+import lensPg from "src/utils/lensPg";
+import syncAddressesToGuild from "src/utils/syncAddressesToGuild";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import syncHQScoreAccountsToGuild from "./syncHQScoreAccountsToGuild";
+
+vi.mock("src/utils/lensPg", () => ({ default: { query: vi.fn() } }));
+vi.mock("src/utils/syncAddressesToGuild", () => ({
+  default: vi.fn(async () => ({ success: true }))
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("syncHQScoreAccountsToGuild", () => {
+  it("queries db and syncs addresses", async () => {
+    const buf = Buffer.from("2".repeat(40), "hex");
+    (lensPg.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { account: buf }
+    ]);
+    const ctx = { json: vi.fn((b: unknown) => b) } as unknown as Context;
+
+    const result = await syncHQScoreAccountsToGuild(ctx);
+
+    expect(lensPg.query).toHaveBeenCalled();
+    expect(syncAddressesToGuild).toHaveBeenCalledWith({
+      addresses: [`0x${buf.toString("hex")}`],
+      roleId: 173446,
+      requirementId: 471245
+    });
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/apps/api/src/routes/cron/guild/syncSubscribersToGuild.test.ts
+++ b/apps/api/src/routes/cron/guild/syncSubscribersToGuild.test.ts
@@ -1,0 +1,34 @@
+import type { Context } from "hono";
+import lensPg from "src/utils/lensPg";
+import syncAddressesToGuild from "src/utils/syncAddressesToGuild";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import syncSubscribersToGuild from "./syncSubscribersToGuild";
+
+vi.mock("src/utils/lensPg", () => ({ default: { query: vi.fn() } }));
+vi.mock("src/utils/syncAddressesToGuild", () => ({
+  default: vi.fn(async () => ({ success: true }))
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("syncSubscribersToGuild", () => {
+  it("queries db and syncs addresses", async () => {
+    const buf = Buffer.from("3".repeat(40), "hex");
+    (lensPg.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { account: buf }
+    ]);
+    const ctx = { json: vi.fn((b: unknown) => b) } as unknown as Context;
+
+    const result = await syncSubscribersToGuild(ctx);
+
+    expect(lensPg.query).toHaveBeenCalled();
+    expect(syncAddressesToGuild).toHaveBeenCalledWith({
+      addresses: [`0x${buf.toString("hex")}`],
+      roleId: 173026,
+      requirementId: 470539
+    });
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/apps/api/src/routes/cron/removeExpiredSubscribers/index.test.ts
+++ b/apps/api/src/routes/cron/removeExpiredSubscribers/index.test.ts
@@ -1,0 +1,50 @@
+import { PERMISSIONS } from "@hey/data/constants";
+import type { Context } from "hono";
+import lensPg from "src/utils/lensPg";
+import signer from "src/utils/signer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import removeExpiredSubscribers from "./index";
+
+vi.mock("src/utils/lensPg", () => ({ default: { query: vi.fn() } }));
+vi.mock("src/utils/signer", () => ({ default: { writeContract: vi.fn() } }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("removeExpiredSubscribers", () => {
+  it("queries db and calls contract", async () => {
+    const buf = Buffer.from("4".repeat(40), "hex");
+    (lensPg.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { account: buf }
+    ]);
+    (
+      signer.writeContract as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue("hash");
+    const ctx = { json: vi.fn((b: unknown) => b) } as unknown as Context;
+
+    const result = await removeExpiredSubscribers(ctx);
+
+    expect(lensPg.query).toHaveBeenCalled();
+    expect(signer.writeContract).toHaveBeenCalledWith({
+      abi: expect.anything(),
+      address: PERMISSIONS.SUBSCRIPTION,
+      functionName: "removeMembers",
+      args: [
+        [
+          {
+            account: `0x${buf.toString("hex")}`,
+            customParams: [],
+            ruleProcessingParams: []
+          }
+        ],
+        []
+      ]
+    });
+    expect(result).toEqual({
+      success: true,
+      addresses: [`0x${buf.toString("hex")}`],
+      hash: "hash"
+    });
+  });
+});

--- a/apps/api/src/routes/og/getAccount.test.ts
+++ b/apps/api/src/routes/og/getAccount.test.ts
@@ -1,0 +1,61 @@
+import type { Context } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import getAccount from "./getAccount";
+import "@hey/indexer/apollo/client";
+import "@hey/helpers/getAccount";
+import "@hey/helpers/getAvatar";
+import { getRedis, setRedis } from "src/utils/redis";
+
+vi.mock("@hey/indexer/apollo/client", () => ({
+  default: vi.fn(() => ({
+    query: vi.fn(async () => ({
+      data: { account: { metadata: { bio: "bio" } } }
+    }))
+  }))
+}));
+vi.mock("@hey/helpers/getAccount", () => ({
+  default: vi.fn(() => ({
+    name: "Alice",
+    link: "/u/alice",
+    usernameWithPrefix: "@alice"
+  }))
+}));
+vi.mock("@hey/helpers/getAvatar", () => ({ default: vi.fn(() => "avatar") }));
+vi.mock("src/utils/redis", () => ({ getRedis: vi.fn(), setRedis: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("og getAccount route", () => {
+  it("generates html and caches result", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const html = vi.fn((b: string) => b);
+    const ctx = {
+      req: { param: vi.fn(() => ({ username: "alice" })) },
+      html
+    } as unknown as Context;
+
+    const result = await getAccount(ctx);
+
+    expect(html).toHaveBeenCalled();
+    expect(String(result)).toContain("Alice (@alice) on Hey");
+    expect(setRedis).toHaveBeenCalled();
+  });
+
+  it("returns cached html when available", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "cached"
+    );
+    const html = vi.fn((b: string) => b);
+    const ctx = {
+      req: { param: vi.fn(() => ({ username: "alice" })) },
+      html
+    } as unknown as Context;
+
+    const result = await getAccount(ctx);
+
+    expect(result).toBe("cached");
+    expect(setRedis).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/og/getGroup.test.ts
+++ b/apps/api/src/routes/og/getGroup.test.ts
@@ -1,0 +1,58 @@
+import type { Context } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import getGroup from "./getGroup";
+import "@hey/indexer/apollo/client";
+import "@hey/helpers/getAvatar";
+import { getRedis, setRedis } from "src/utils/redis";
+
+vi.mock("@hey/indexer/apollo/client", () => ({
+  default: vi.fn(() => ({
+    query: vi.fn(async () => ({
+      data: {
+        group: {
+          metadata: { name: "Group", description: "desc" },
+          address: "0x1"
+        }
+      }
+    }))
+  }))
+}));
+vi.mock("@hey/helpers/getAvatar", () => ({ default: vi.fn(() => "avatar") }));
+vi.mock("src/utils/redis", () => ({ getRedis: vi.fn(), setRedis: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("og getGroup route", () => {
+  it("generates html and caches result", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const html = vi.fn((b: string) => b);
+    const ctx = {
+      req: { param: vi.fn(() => ({ address: "0x1" })) },
+      html
+    } as unknown as Context;
+
+    const result = await getGroup(ctx);
+
+    expect(html).toHaveBeenCalled();
+    expect(String(result)).toContain("Group on Hey");
+    expect(setRedis).toHaveBeenCalled();
+  });
+
+  it("returns cached html when available", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "cached"
+    );
+    const html = vi.fn((b: string) => b);
+    const ctx = {
+      req: { param: vi.fn(() => ({ address: "0x1" })) },
+      html
+    } as unknown as Context;
+
+    const result = await getGroup(ctx);
+
+    expect(result).toBe("cached");
+    expect(setRedis).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/og/getPost.test.ts
+++ b/apps/api/src/routes/og/getPost.test.ts
@@ -1,0 +1,76 @@
+import type { Context } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import getPost from "./getPost";
+import "@hey/indexer/apollo/client";
+import "@hey/helpers/getAccount";
+import "@hey/helpers/getAvatar";
+import "@hey/helpers/getPostData";
+import { getRedis, setRedis } from "src/utils/redis";
+
+vi.mock("@hey/indexer/apollo/client", () => ({
+  default: vi.fn(() => ({
+    query: vi.fn(async () => ({
+      data: {
+        post: {
+          __typename: "Post",
+          slug: "slug",
+          author: {},
+          metadata: {},
+          stats: {
+            collects: 1,
+            tips: 2,
+            comments: 3,
+            reactions: 4,
+            reposts: 5,
+            quotes: 6
+          }
+        }
+      }
+    }))
+  }))
+}));
+vi.mock("@hey/helpers/getAccount", () => ({
+  default: vi.fn(() => ({ usernameWithPrefix: "@alice" }))
+}));
+vi.mock("@hey/helpers/getAvatar", () => ({ default: vi.fn(() => "avatar") }));
+vi.mock("@hey/helpers/getPostData", () => ({
+  default: vi.fn(() => ({ content: "Hello" }))
+}));
+vi.mock("src/utils/redis", () => ({ getRedis: vi.fn(), setRedis: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("og getPost route", () => {
+  it("generates html and caches result", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const html = vi.fn((b: string) => b);
+    const ctx = {
+      req: { param: vi.fn(() => ({ slug: "slug" })) },
+      html
+    } as unknown as Context;
+
+    const result = await getPost(ctx);
+
+    expect(html).toHaveBeenCalled();
+    expect(String(result)).toContain("Post by @alice on Hey");
+    expect(setRedis).toHaveBeenCalled();
+  });
+
+  it("returns cached html when available", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "cached"
+    );
+    const html = vi.fn((b: string) => b);
+    const ctx = {
+      req: { param: vi.fn(() => ({ slug: "slug" })) },
+      html
+    } as unknown as Context;
+
+    const result = await getPost(ctx);
+
+    expect(result).toBe("cached");
+    expect(setRedis).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/preferences/getPreferences.test.ts
+++ b/apps/api/src/routes/preferences/getPreferences.test.ts
@@ -1,0 +1,66 @@
+import type { Context } from "hono";
+import prisma from "src/prisma/client";
+import { getRedis, setRedis } from "src/utils/redis";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import getPreferences from "./getPreferences";
+
+vi.mock("src/prisma/client", () => ({
+  default: { preference: { findUnique: vi.fn() } }
+}));
+vi.mock("src/utils/redis", () => ({ getRedis: vi.fn(), setRedis: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getPreferences route", () => {
+  it("returns cached value when available", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      '{"appIcon":1,"includeLowScore":true}'
+    );
+    const ctx = {
+      get: vi.fn(() => "0x1"),
+      json: vi.fn((b: unknown) => b)
+    } as unknown as Context;
+
+    const result = await getPreferences(ctx);
+
+    expect(ctx.json).toHaveBeenCalledWith({
+      success: true,
+      cached: true,
+      data: { appIcon: 1, includeLowScore: true }
+    });
+    expect(result).toEqual({
+      success: true,
+      cached: true,
+      data: { appIcon: 1, includeLowScore: true }
+    });
+    expect(prisma.preference.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("fetches from db and caches when not cached", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (
+      prisma.preference.findUnique as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ appIcon: 2, includeLowScore: false });
+    const ctx = {
+      get: vi.fn(() => "0x1"),
+      json: vi.fn((b: unknown) => b)
+    } as unknown as Context;
+
+    const result = await getPreferences(ctx);
+
+    expect(prisma.preference.findUnique).toHaveBeenCalledWith({
+      where: { accountAddress: "0x1" }
+    });
+    expect(setRedis).toHaveBeenCalled();
+    expect(ctx.json).toHaveBeenCalledWith({
+      success: true,
+      data: { appIcon: 2, includeLowScore: false }
+    });
+    expect(result).toEqual({
+      success: true,
+      data: { appIcon: 2, includeLowScore: false }
+    });
+  });
+});

--- a/apps/api/src/routes/preferences/updatePreferences.test.ts
+++ b/apps/api/src/routes/preferences/updatePreferences.test.ts
@@ -1,0 +1,44 @@
+import type { Context } from "hono";
+import prisma from "src/prisma/client";
+import { delRedis } from "src/utils/redis";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import updatePreferences from "./updatePreferences";
+
+vi.mock("src/prisma/client", () => ({
+  default: { preference: { upsert: vi.fn() } }
+}));
+vi.mock("src/utils/redis", () => ({ delRedis: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("updatePreferences route", () => {
+  it("updates preferences and clears cache", async () => {
+    (
+      prisma.preference.upsert as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ appIcon: 3, includeLowScore: true });
+    const ctx = {
+      req: { json: vi.fn(async () => ({ appIcon: 3, includeLowScore: true })) },
+      get: vi.fn(() => "0x1"),
+      json: vi.fn((b: unknown) => b)
+    } as unknown as Context;
+
+    const result = await updatePreferences(ctx);
+
+    expect(prisma.preference.upsert).toHaveBeenCalledWith({
+      create: { appIcon: 3, includeLowScore: true, accountAddress: "0x1" },
+      update: { appIcon: 3, includeLowScore: true },
+      where: { accountAddress: "0x1" }
+    });
+    expect(delRedis).toHaveBeenCalledWith("preferences:0x1");
+    expect(ctx.json).toHaveBeenCalledWith({
+      success: true,
+      data: { appIcon: 3, includeLowScore: true }
+    });
+    expect(result).toEqual({
+      success: true,
+      data: { appIcon: 3, includeLowScore: true }
+    });
+  });
+});

--- a/apps/api/src/routes/sitemap/accounts/accountSitemap.test.ts
+++ b/apps/api/src/routes/sitemap/accounts/accountSitemap.test.ts
@@ -1,0 +1,58 @@
+import type { Context } from "hono";
+import lensPg from "src/utils/lensPg";
+import { getRedis, setRedis } from "src/utils/redis";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import accountSitemap from "./accountSitemap";
+
+vi.mock("src/utils/lensPg", () => ({ default: { query: vi.fn() } }));
+vi.mock("src/utils/redis", () => ({
+  getRedis: vi.fn(),
+  setRedis: vi.fn(),
+  hoursToSeconds: vi.fn(() => 1)
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("accountSitemap", () => {
+  it("returns cached usernames when available", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      '["bob"]'
+    );
+    const header = vi.fn();
+    const body = vi.fn((c: unknown) => c);
+    const ctx = {
+      req: { param: vi.fn(() => ({ "batch.xml": "1.xml" })) },
+      header,
+      body
+    } as unknown as Context;
+
+    const result = await accountSitemap(ctx);
+
+    expect(body).toHaveBeenCalled();
+    expect(result).toContain("https://hey.xyz/u/bob");
+    expect(lensPg.query).not.toHaveBeenCalled();
+    expect(setRedis).not.toHaveBeenCalled();
+  });
+
+  it("queries db and caches when not cached", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (lensPg.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { local_name: "alice" }
+    ]);
+    const header = vi.fn();
+    const body = vi.fn((c: unknown) => c);
+    const ctx = {
+      req: { param: vi.fn(() => ({ "batch.xml": "1.xml" })) },
+      header,
+      body
+    } as unknown as Context;
+
+    const result = await accountSitemap(ctx);
+
+    expect(lensPg.query).toHaveBeenCalled();
+    expect(setRedis).toHaveBeenCalled();
+    expect(result).toContain("https://hey.xyz/u/alice");
+  });
+});

--- a/apps/api/src/routes/sitemap/accounts/accountsSitemapIndex.test.ts
+++ b/apps/api/src/routes/sitemap/accounts/accountsSitemapIndex.test.ts
@@ -1,0 +1,48 @@
+import type { Context } from "hono";
+import lensPg from "src/utils/lensPg";
+import { getRedis, setRedis } from "src/utils/redis";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import accountsSitemapIndex from "./accountsSitemapIndex";
+
+vi.mock("src/utils/lensPg", () => ({ default: { query: vi.fn() } }));
+vi.mock("src/utils/redis", () => ({
+  getRedis: vi.fn(),
+  setRedis: vi.fn(),
+  hoursToSeconds: vi.fn(() => 1)
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("accountsSitemapIndex", () => {
+  it("returns cached value when available", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue("2");
+    const header = vi.fn();
+    const body = vi.fn((c: unknown) => c);
+    const ctx = { header, body } as unknown as Context;
+
+    const result = await accountsSitemapIndex(ctx);
+
+    expect(header).toHaveBeenCalledWith("Content-Type", "application/xml");
+    expect(result).toContain("<sitemapindex");
+    expect(lensPg.query).not.toHaveBeenCalled();
+    expect(setRedis).not.toHaveBeenCalled();
+  });
+
+  it("queries db and caches when not cached", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (lensPg.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { count: 2 }
+    ]);
+    const header = vi.fn();
+    const body = vi.fn((c: unknown) => c);
+    const ctx = { header, body } as unknown as Context;
+
+    const result = await accountsSitemapIndex(ctx);
+
+    expect(lensPg.query).toHaveBeenCalled();
+    expect(setRedis).toHaveBeenCalled();
+    expect(result).toContain("<sitemapindex");
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for AI translate route
- cover OG HTML routes and caching
- test user preference routes
- verify cron handlers interactions
- add sitemap account tests

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68444ba411e883309eec55e14bb5a3dd