### PR TITLE
Add Apollo client tests

### DIFF
--- a/packages/indexer/apollo/client.test.ts
+++ b/packages/indexer/apollo/client.test.ts
@@ -1,0 +1,54 @@
+import type { ApolloLink } from "@apollo/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import httpLink from "./httpLink";
+import retryLink from "./retryLink";
+
+// biome-ignore lint/style/noVar: hoisted mocks require var declarations
+var fromMock: ReturnType<typeof vi.fn>;
+// biome-ignore lint/style/noVar: hoisted mocks require var declarations
+var ApolloClientMock: ReturnType<typeof vi.fn>;
+
+vi.mock("@apollo/client", async () => {
+  const actual: any = await vi.importActual("@apollo/client");
+  fromMock = vi.fn((links: ApolloLink[]) => links);
+  ApolloClientMock = vi.fn().mockImplementation((config: any) => ({ config }));
+  return {
+    ...actual,
+    ApolloClient: ApolloClientMock,
+    from: fromMock
+  };
+});
+
+import apolloClient from "./client";
+
+describe("apolloClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates client without auth link", () => {
+    const client = apolloClient() as any;
+
+    expect(fromMock).toHaveBeenCalledWith([retryLink, httpLink]);
+    expect(ApolloClientMock).toHaveBeenCalled();
+    expect(ApolloClientMock.mock.calls[0][0].link).toEqual([
+      retryLink,
+      httpLink
+    ]);
+    expect(client.config.link).toEqual([retryLink, httpLink]);
+  });
+
+  it("creates client with auth link", () => {
+    const authLink = {} as ApolloLink;
+    const client = apolloClient(authLink) as any;
+
+    expect(fromMock).toHaveBeenCalledWith([authLink, retryLink, httpLink]);
+    expect(ApolloClientMock).toHaveBeenCalled();
+    expect(ApolloClientMock.mock.calls[0][0].link).toEqual([
+      authLink,
+      retryLink,
+      httpLink
+    ]);
+    expect(client.config.link).toEqual([authLink, retryLink, httpLink]);
+  });
+});

--- a/packages/indexer/apollo/helpers/cursorBasedPagination.test.ts
+++ b/packages/indexer/apollo/helpers/cursorBasedPagination.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import cursorBasedPagination from "./cursorBasedPagination";
+
+describe("cursorBasedPagination", () => {
+  const fieldPolicy = cursorBasedPagination<any>([]);
+
+  it("merges existing and incoming items", () => {
+    const existing = {
+      items: [{ id: 1 }],
+      pageInfo: { __typename: "PaginatedResultInfo", prev: null, next: "a" }
+    };
+    const incoming = {
+      items: [{ id: 2 }],
+      pageInfo: { __typename: "PaginatedResultInfo", prev: "b", next: "c" }
+    };
+
+    const result = (fieldPolicy.merge as any)?.(existing, incoming, {} as any);
+
+    expect(result.items).toEqual([...existing.items, ...incoming.items]);
+    expect(result.pageInfo).toBe(incoming.pageInfo);
+  });
+
+  it("reads items and clones pageInfo", () => {
+    const existing = {
+      items: [{ id: 1 }],
+      pageInfo: { __typename: "PaginatedResultInfo", prev: null, next: "a" }
+    };
+
+    const result = (fieldPolicy.read as any)?.(existing, {} as any);
+
+    expect(result).toEqual({
+      ...existing,
+      pageInfo: { ...existing.pageInfo }
+    });
+    expect(result).not.toBe(existing);
+    expect(result.pageInfo).not.toBe(existing.pageInfo);
+  });
+});

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -6,7 +6,8 @@
   "main": "generated.ts",
   "scripts": {
     "codegen": "graphql-codegen",
-    "typecheck": "tsc --pretty"
+    "typecheck": "tsc --pretty",
+    "test": "vitest"
   },
   "dependencies": {
     "@apollo/client": "^3.13.8",
@@ -21,6 +22,7 @@
     "@graphql-codegen/typescript-react-apollo": "^4.3.3",
     "@hey/config": "workspace:*",
     "@types/node": "^22.15.30",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.2"
   }
 }

--- a/packages/indexer/vitest.config.ts
+++ b/packages/indexer/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node"
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,6 +405,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.2.2
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
 
   packages/types:
     dependencies:


### PR DESCRIPTION
## Summary
- add vitest config for indexer
- add cursor based pagination tests
- add apollo client link chain tests

## Testing
- `CI=1 pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68444bbc6fc0833098151ff30ddd1039