### PR TITLE
Add data package tests

### DIFF
--- a/packages/data/rpcs.test.ts
+++ b/packages/data/rpcs.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { LENS_MAINNET_RPCS, LENS_TESTNET_RPCS } from "./rpcs";
+
+describe("rpcs", () => {
+  it("contains expected mainnet RPCs", () => {
+    expect(LENS_MAINNET_RPCS).toEqual([
+      "https://rpc.lens.xyz",
+      "https://api.lens.matterhosted.dev",
+      "https://lens-mainnet.g.alchemy.com/v2/N_HuqeYE3mr_enxw-BGFI2rOm1U7bhGy"
+    ]);
+  });
+
+  it("contains expected testnet RPCs", () => {
+    expect(LENS_TESTNET_RPCS).toEqual([
+      "https://rpc.testnet.lens.dev",
+      "https://lens-sepolia.g.alchemy.com/v2/N_HuqeYE3mr_enxw-BGFI2rOm1U7bhGy"
+    ]);
+  });
+});

--- a/packages/data/tokens.test.ts
+++ b/packages/data/tokens.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const reset = () => {
+  vi.resetModules();
+  process.env.NEXT_PUBLIC_LENS_NETWORK = undefined as any;
+};
+
+afterEach(() => {
+  reset();
+});
+
+describe("tokens", () => {
+  it("returns mainnet tokens by default", async () => {
+    const { tokens } = await import("./tokens");
+    expect(tokens.map((t) => t.contractAddress)).toEqual([
+      "0x6bDc36E20D267Ff0dd6097799f82e78907105e2F",
+      "0xB0588f9A9cADe7CD5f194a5fe77AcD6A58250f82"
+    ]);
+  });
+
+  it("returns testnet tokens when LENS_NETWORK=testnet", async () => {
+    process.env.NEXT_PUBLIC_LENS_NETWORK = "testnet";
+    const { tokens } = await import("./tokens");
+    expect(tokens.map((t) => t.contractAddress)).toEqual([
+      "0xeee5a340Cdc9c179Db25dea45AcfD5FE8d4d3eB8"
+    ]);
+  });
+});

--- a/packages/data/utils/getEnvConfig.test.ts
+++ b/packages/data/utils/getEnvConfig.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const load = async (network?: string) => {
+  vi.resetModules();
+  vi.doMock("../constants", () => ({ LENS_NETWORK: network ?? "mainnet" }));
+  const mod = await import("./getEnvConfig");
+  vi.unmock("../constants");
+  return mod.default;
+};
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe("getEnvConfig", () => {
+  it("returns testnet endpoints when LENS_NETWORK is testnet", async () => {
+    const getEnvConfig = await load("testnet");
+    const config = getEnvConfig();
+    expect(config.lensApiEndpoint).toBe("https://api.testnet.lens.xyz/graphql");
+    expect(config.defaultCollectToken).toBe(
+      "0xeee5a340Cdc9c179Db25dea45AcfD5FE8d4d3eB8"
+    );
+    expect(config.appAddress).toBe(
+      "0x688419B0299f3Ed8E80eBCa71ad05Ac23d20822b"
+    );
+  });
+
+  it("returns staging endpoints when LENS_NETWORK is staging", async () => {
+    const getEnvConfig = await load("staging");
+    const config = getEnvConfig();
+    expect(config.lensApiEndpoint).toBe("https://api.staging.lens.xyz/graphql");
+    expect(config.defaultCollectToken).toBe(
+      "0xeee5a340Cdc9c179Db25dea45AcfD5FE8d4d3eB8"
+    );
+    expect(config.appAddress).toBe(
+      "0x688419B0299f3Ed8E80eBCa71ad05Ac23d20822b"
+    );
+  });
+
+  it("returns mainnet endpoints by default", async () => {
+    const getEnvConfig = await load();
+    const config = getEnvConfig();
+    expect(config.lensApiEndpoint).toBe("https://api.lens.xyz/graphql");
+    expect(config.defaultCollectToken).toBe(
+      "0x6bDc36E20D267Ff0dd6097799f82e78907105e2F"
+    );
+    expect(config.appAddress).toBe(
+      "0x1eFA8F82d9E919F6b6A5f1701131c9Cb1a943BAA"
+    );
+  });
+});

--- a/packages/data/utils/regexLookbehindAvailable.test.ts
+++ b/packages/data/utils/regexLookbehindAvailable.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mockReplace = (supported: boolean) => {
+  const original = String.prototype.replace;
+  vi.spyOn(String.prototype, "replace").mockImplementation(function (
+    this: string,
+    search,
+    value
+  ) {
+    if (search?.toString?.().includes("(?<=a)b")) {
+      if (supported) {
+        return "ac";
+      }
+      throw new Error("not supported");
+    }
+    return original.call(this, search as any, value as any);
+  });
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe("regexLookbehindAvailable", () => {
+  it("is boolean when lookbehind supported", async () => {
+    mockReplace(true);
+    const value = (await import("./regexLookbehindAvailable")).default;
+    expect(typeof value).toBe("boolean");
+    expect(value).toBe(true);
+  });
+
+  it("is boolean when lookbehind unsupported", async () => {
+    mockReplace(false);
+    const value = (await import("./regexLookbehindAvailable")).default;
+    expect(typeof value).toBe("boolean");
+    expect(value).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- test getEnvConfig for different networks
- validate regexLookbehindAvailable helper
- check tokens and rpc lists

## Testing
- `CI=1 pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build` *(fails: comment annotation issue)*

------
https://chatgpt.com/codex/tasks/task_e_68444bbe642883309c8408736cdbf5e4