### PR TITLE
Share apollo client instance

### DIFF
--- a/apps/api/src/routes/og/getAccount.ts
+++ b/apps/api/src/routes/og/getAccount.ts
@@ -19,7 +19,7 @@ const getAccount = async (ctx: Context) => {
       return ctx.html(cachedAccount, 200);
     }
 
-    const { data } = await apolloClient().query({
+    const { data } = await apolloClient.query({
       query: AccountDocument,
       variables: { request: { username: { localName: username } } },
       fetchPolicy: "no-cache"

--- a/apps/api/src/routes/og/getGroup.ts
+++ b/apps/api/src/routes/og/getGroup.ts
@@ -18,7 +18,7 @@ const getGroup = async (ctx: Context) => {
       return ctx.html(cachedGroup, 200);
     }
 
-    const { data } = await apolloClient().query({
+    const { data } = await apolloClient.query({
       query: GroupDocument,
       variables: { request: { group: address } },
       fetchPolicy: "no-cache"

--- a/apps/api/src/routes/og/getPost.ts
+++ b/apps/api/src/routes/og/getPost.ts
@@ -19,7 +19,7 @@ const getPost = async (ctx: Context) => {
       return ctx.html(cachedPost, 200);
     }
 
-    const { data } = await apolloClient().query({
+    const { data } = await apolloClient.query({
       query: PostDocument,
       variables: { request: { post: slug } },
       fetchPolicy: "no-cache"

--- a/apps/web/src/components/Common/Providers/index.tsx
+++ b/apps/web/src/components/Common/Providers/index.tsx
@@ -1,7 +1,7 @@
 import authLink from "@/helpers/authLink";
 import { ThemeProvider } from "@/hooks/useTheme";
 import { ApolloProvider } from "@apollo/client";
-import apolloClient from "@hey/indexer/apollo/client";
+import { createApolloClient } from "@hey/indexer/apollo/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import ErrorBoundary from "../ErrorBoundary";
@@ -12,7 +12,7 @@ export const queryClient = new QueryClient({
   defaultOptions: { queries: { refetchOnWindowFocus: false } }
 });
 
-const lensApolloClient = apolloClient(authLink);
+const lensApolloClient = createApolloClient(authLink);
 
 interface ProvidersProps {
   children: ReactNode;

--- a/packages/indexer/apollo/client.ts
+++ b/packages/indexer/apollo/client.ts
@@ -4,7 +4,7 @@ import cache from "./cache";
 import httpLink from "./httpLink";
 import retryLink from "./retryLink";
 
-const apolloClient = (authLink?: ApolloLink) =>
+export const createApolloClient = (authLink?: ApolloLink) =>
   new ApolloClient({
     cache,
     connectToDevTools: true,
@@ -12,5 +12,7 @@ const apolloClient = (authLink?: ApolloLink) =>
       ? from([authLink, retryLink, httpLink])
       : from([retryLink, httpLink])
   });
+
+const apolloClient = createApolloClient();
 
 export default apolloClient;


### PR DESCRIPTION
## Summary
- expose a singleton Apollo client from `packages/indexer`
- use this client in OG API routes
- keep a helper for creating ad-hoc clients
- update web provider to use the new helper

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68444e6924ac83309b596c69cc42473e