### PR TITLE
Escape html in OG metadata

### DIFF
--- a/apps/api/src/routes/og/getAccount.ts
+++ b/apps/api/src/routes/og/getAccount.ts
@@ -1,4 +1,5 @@
 import { STATIC_IMAGES_URL, TRANSFORMS } from "@hey/data/constants";
+import escapeHtml from "@hey/helpers/escapeHtml";
 import { default as getAccountData } from "@hey/helpers/getAccount";
 import getAvatar from "@hey/helpers/getAvatar";
 import { AccountDocument } from "@hey/indexer";
@@ -35,6 +36,11 @@ const getAccount = async (ctx: Context) => {
     const description = (account?.metadata?.bio || title).slice(0, 155);
     const avatar = getAvatar(account, TRANSFORMS.AVATAR_BIG);
 
+    const escTitle = escapeHtml(title);
+    const escDescription = escapeHtml(description);
+    const escName = escapeHtml(name);
+    const escUsernameWithPrefix = escapeHtml(usernameWithPrefix);
+
     const jsonLd = {
       "@context": "https://schema.org",
       "@type": "Person",
@@ -57,28 +63,28 @@ const getAccount = async (ctx: Context) => {
         <head>
           <meta charSet="utf-8" />
           <meta name="viewport" content="width=device-width" />
-          <title>${title}</title>
-          <meta name="description" content="${description}" />
-          <meta property="og:title" content="${title}" />
-          <meta property="og:description" content="${description}" />
+          <title>${escTitle}</title>
+          <meta name="description" content="${escDescription}" />
+          <meta property="og:title" content="${escTitle}" />
+          <meta property="og:description" content="${escDescription}" />
           <meta property="og:type" content="profile" />
           <meta property="og:site_name" content="Hey" />
           <meta property="og:url" content="https://hey.xyz${link}" />
           <meta property="og:image" content="${avatar}" />
           <meta property="og:logo" content="${STATIC_IMAGES_URL}/app-icon/0.png" />
           <meta name="twitter:card" content="summary" />
-          <meta name="twitter:title" content="${title}" />
-          <meta name="twitter:description" content="${description}" />
+          <meta name="twitter:title" content="${escTitle}" />
+          <meta name="twitter:description" content="${escDescription}" />
           <meta property="twitter:image" content="${avatar}" />
           <meta name="twitter:site" content="@heydotxyz" />
           <link rel="canonical" href="https://hey.xyz${link}" />
         </head>
         <body>
           <script type="application/ld+json">${raw(escapedJsonLd)}</script>
-          <img src="${avatar}" alt="${name}" height="100" width="100" />
-          <h1>${name || username}</h1>
-          <h2>${usernameWithPrefix}</h2>
-          <h3>${description}</h3>
+          <img src="${avatar}" alt="${escName}" height="100" width="100" />
+          <h1>${escName || username}</h1>
+          <h2>${escUsernameWithPrefix}</h2>
+          <h3>${escDescription}</h3>
         </body>
       </html>
     `;

--- a/apps/api/src/routes/og/getGroup.ts
+++ b/apps/api/src/routes/og/getGroup.ts
@@ -1,4 +1,5 @@
 import { STATIC_IMAGES_URL, TRANSFORMS } from "@hey/data/constants";
+import escapeHtml from "@hey/helpers/escapeHtml";
 import getAvatar from "@hey/helpers/getAvatar";
 import { GroupDocument, type GroupFragment } from "@hey/indexer";
 import apolloClient from "@hey/indexer/apollo/client";
@@ -34,6 +35,10 @@ const getGroup = async (ctx: Context) => {
     const description = (group?.metadata?.description || title).slice(0, 155);
     const avatar = getAvatar(group, TRANSFORMS.AVATAR_BIG);
 
+    const escTitle = escapeHtml(title);
+    const escDescription = escapeHtml(description);
+    const escName = escapeHtml(name);
+
     const jsonLd = {
       "@context": "https://schema.org",
       "@type": "Organization",
@@ -56,27 +61,27 @@ const getGroup = async (ctx: Context) => {
         <head>
           <meta charSet="utf-8" />
           <meta name="viewport" content="width=device-width" />
-          <title>${title}</title>
-          <meta name="description" content="${description}" />
-          <meta property="og:title" content="${title}" />
-          <meta property="og:description" content="${description}" />
+          <title>${escTitle}</title>
+          <meta name="description" content="${escDescription}" />
+          <meta property="og:title" content="${escTitle}" />
+          <meta property="og:description" content="${escDescription}" />
           <meta property="og:type" content="profile" />
           <meta property="og:site_name" content="Hey" />
           <meta property="og:url" content="https://hey.xyz/g/${group.address}" />
           <meta property="og:image" content="${avatar}" />
           <meta property="og:logo" content="${STATIC_IMAGES_URL}/app-icon/0.png" />
           <meta name="twitter:card" content="summary" />
-          <meta name="twitter:title" content="${title}" />
-          <meta name="twitter:description" content="${description}" />
+          <meta name="twitter:title" content="${escTitle}" />
+          <meta name="twitter:description" content="${escDescription}" />
           <meta property="twitter:image" content="${avatar}" />
           <meta name="twitter:site" content="@heydotxyz" />
           <link rel="canonical" href="https://hey.xyz/g/${group.address}" />
         </head>
         <body>
           <script type="application/ld+json">${raw(escapedJsonLd)}</script>
-          <img src="${avatar}" alt="${title}" height="100" width="100" />
-          <h1>${name}</h1>
-          <h2>${description}</h2>
+          <img src="${avatar}" alt="${escTitle}" height="100" width="100" />
+          <h1>${escName}</h1>
+          <h2>${escDescription}</h2>
         </body>
       </html>
     `;

--- a/apps/api/src/routes/og/getPost.ts
+++ b/apps/api/src/routes/og/getPost.ts
@@ -1,4 +1,5 @@
 import { STATIC_IMAGES_URL, TRANSFORMS } from "@hey/data/constants";
+import escapeHtml from "@hey/helpers/escapeHtml";
 import getAccount from "@hey/helpers/getAccount";
 import getAvatar from "@hey/helpers/getAvatar";
 import getPostData from "@hey/helpers/getPostData";
@@ -37,30 +38,33 @@ const getPost = async (ctx: Context) => {
     const description = (filteredContent || title).slice(0, 155);
     const postUrl = `https://hey.xyz/posts/${post.slug}`;
 
+    const escTitle = escapeHtml(title);
+    const escDescription = escapeHtml(description);
+
     const ogHtml = html`
       <html>
         <head>
           <meta charSet="utf-8" />
           <meta name="viewport" content="width=device-width" />
-          <title>${title}</title>
-          <meta name="description" content="${description}" />
-          <meta property="og:title" content="${title}" />
-          <meta property="og:description" content="${description}" />
+          <title>${escTitle}</title>
+          <meta name="description" content="${escDescription}" />
+          <meta property="og:title" content="${escTitle}" />
+          <meta property="og:description" content="${escDescription}" />
           <meta property="og:type" content="article" />
           <meta property="og:site_name" content="Hey" />
           <meta property="og:url" content="https://hey.xyz/posts/${post.slug}" />
           <meta property="og:logo" content="${STATIC_IMAGES_URL}/app-icon/0.png" />
           <meta property="og:image" content="${getAvatar(author, TRANSFORMS.AVATAR_BIG)}" />
           <meta name="twitter:card" content="summary" />
-          <meta name="twitter:title" content="${title}" />
-          <meta name="twitter:description" content="${description}" />
+          <meta name="twitter:title" content="${escTitle}" />
+          <meta name="twitter:description" content="${escDescription}" />
           <meta property="twitter:image" content="${getAvatar(author, TRANSFORMS.AVATAR_BIG)}" />
           <meta name="twitter:site" content="@heydotxyz" />
           <link rel="canonical" href="https://hey.xyz/posts/${post.slug}" />
         </head>
         <body>
-          <h1>${title}</h1>
-          <h2>${description}</h2>
+          <h1>${escTitle}</h1>
+          <h2>${escDescription}</h2>
           <div>
             <b>Stats</b>
             <ul>

--- a/packages/helpers/escapeHtml.test.ts
+++ b/packages/helpers/escapeHtml.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import escapeHtml from "./escapeHtml";
+
+describe("escapeHtml", () => {
+  it("escapes angle brackets", () => {
+    expect(escapeHtml("<tag>")).toBe("&lt;tag&gt;");
+  });
+
+  it("escapes quotes and ampersands", () => {
+    expect(escapeHtml('"Tom & Jerry"')).toBe("&quot;Tom &amp; Jerry&quot;");
+  });
+
+  it("handles null or undefined", () => {
+    expect(escapeHtml(undefined)).toBe("");
+    expect(escapeHtml(null)).toBe("");
+  });
+});

--- a/packages/helpers/escapeHtml.ts
+++ b/packages/helpers/escapeHtml.ts
@@ -1,0 +1,10 @@
+const escapeHtml = (str?: string | null): string => {
+  return String(str ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+};
+
+export default escapeHtml;


### PR DESCRIPTION
## Summary
- add HTML escaping helper with unit tests
- apply escaping to OG account, group and post routes

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build` *(fails: Vite build error)*

------
https://chatgpt.com/codex/tasks/task_e_68444c12862c8330b8a9b5a72a15b89f