### PR TITLE
Fix OG route tests

### DIFF
--- a/apps/api/src/routes/og/getAccount.test.ts
+++ b/apps/api/src/routes/og/getAccount.test.ts
@@ -7,11 +7,11 @@ import "@hey/helpers/getAvatar";
 import { getRedis, setRedis } from "src/utils/redis";
 
 vi.mock("@hey/indexer/apollo/client", () => ({
-  default: vi.fn(() => ({
+  default: {
     query: vi.fn(async () => ({
       data: { account: { metadata: { bio: "bio" } } }
     }))
-  }))
+  }
 }));
 vi.mock("@hey/helpers/getAccount", () => ({
   default: vi.fn(() => ({

--- a/apps/api/src/routes/og/getGroup.test.ts
+++ b/apps/api/src/routes/og/getGroup.test.ts
@@ -6,7 +6,7 @@ import "@hey/helpers/getAvatar";
 import { getRedis, setRedis } from "src/utils/redis";
 
 vi.mock("@hey/indexer/apollo/client", () => ({
-  default: vi.fn(() => ({
+  default: {
     query: vi.fn(async () => ({
       data: {
         group: {
@@ -15,7 +15,7 @@ vi.mock("@hey/indexer/apollo/client", () => ({
         }
       }
     }))
-  }))
+  }
 }));
 vi.mock("@hey/helpers/getAvatar", () => ({ default: vi.fn(() => "avatar") }));
 vi.mock("src/utils/redis", () => ({ getRedis: vi.fn(), setRedis: vi.fn() }));

--- a/apps/api/src/routes/og/getPost.test.ts
+++ b/apps/api/src/routes/og/getPost.test.ts
@@ -8,7 +8,7 @@ import "@hey/helpers/getPostData";
 import { getRedis, setRedis } from "src/utils/redis";
 
 vi.mock("@hey/indexer/apollo/client", () => ({
-  default: vi.fn(() => ({
+  default: {
     query: vi.fn(async () => ({
       data: {
         post: {
@@ -27,7 +27,7 @@ vi.mock("@hey/indexer/apollo/client", () => ({
         }
       }
     }))
-  }))
+  }
 }));
 vi.mock("@hey/helpers/getAccount", () => ({
   default: vi.fn(() => ({ usernameWithPrefix: "@alice" }))


### PR DESCRIPTION
## Summary
- update Apollo client mocks to be objects rather than functions

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build` *(fails: vite build error)*

------
https://chatgpt.com/codex/tasks/task_e_68452bfc4b9083309796f2481cf003c5