### PR TITLE
Add datetime helper tests

### DIFF
--- a/apps/web/src/helpers/datetime/formatDate.test.ts
+++ b/apps/web/src/helpers/datetime/formatDate.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import formatDate from "./formatDate";
+
+describe("formatDate", () => {
+  it("formats date using default pattern", () => {
+    expect(formatDate(new Date("2023-02-01T00:00:00Z"))).toBe(
+      "February 1, 2023"
+    );
+  });
+
+  it("formats date with custom pattern", () => {
+    expect(formatDate("2024-12-25", "YYYY/MM/DD")).toBe("2024/12/25");
+  });
+});

--- a/apps/web/src/helpers/datetime/formatRelativeOrAbsolute.test.ts
+++ b/apps/web/src/helpers/datetime/formatRelativeOrAbsolute.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import formatRelativeOrAbsolute from "./formatRelativeOrAbsolute";
+
+describe("formatRelativeOrAbsolute", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("formats seconds ago", () => {
+    vi.setSystemTime(new Date("2023-05-10T12:00:00Z"));
+    expect(formatRelativeOrAbsolute(new Date("2023-05-10T11:59:30Z"))).toBe(
+      "30s"
+    );
+  });
+
+  it("formats minutes ago", () => {
+    vi.setSystemTime(new Date("2023-05-10T12:00:00Z"));
+    expect(formatRelativeOrAbsolute(new Date("2023-05-10T11:58:00Z"))).toBe(
+      "2m"
+    );
+  });
+
+  it("formats hours ago", () => {
+    vi.setSystemTime(new Date("2023-05-10T12:00:00Z"));
+    expect(formatRelativeOrAbsolute(new Date("2023-05-10T09:00:00Z"))).toBe(
+      "3h"
+    );
+  });
+
+  it("formats days under a week", () => {
+    vi.setSystemTime(new Date("2023-05-10T12:00:00Z"));
+    expect(formatRelativeOrAbsolute(new Date("2023-05-05T12:00:00Z"))).toBe(
+      "5d"
+    );
+  });
+
+  it("formats absolute date in same year", () => {
+    vi.setSystemTime(new Date("2023-05-10T12:00:00Z"));
+    expect(formatRelativeOrAbsolute(new Date("2023-04-30T12:00:00Z"))).toBe(
+      "Apr 30"
+    );
+  });
+
+  it("formats absolute date in different year", () => {
+    vi.setSystemTime(new Date("2023-05-10T12:00:00Z"));
+    expect(formatRelativeOrAbsolute(new Date("2022-04-05T12:00:00Z"))).toBe(
+      "Apr 5, 2022"
+    );
+  });
+});

--- a/apps/web/src/helpers/datetime/getNumberOfDaysFromDate.test.ts
+++ b/apps/web/src/helpers/datetime/getNumberOfDaysFromDate.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import getNumberOfDaysFromDate from "./getNumberOfDaysFromDate";
+
+describe("getNumberOfDaysFromDate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns positive difference for future dates", () => {
+    vi.setSystemTime(new Date("2023-05-05T00:00:00Z"));
+    expect(getNumberOfDaysFromDate(new Date("2023-05-10T00:00:00Z"))).toBe(5);
+  });
+
+  it("returns negative difference for past dates", () => {
+    vi.setSystemTime(new Date("2023-05-05T00:00:00Z"));
+    expect(getNumberOfDaysFromDate(new Date("2023-05-02T00:00:00Z"))).toBe(-3);
+  });
+});

--- a/apps/web/src/helpers/datetime/getTimeAddedNDay.test.ts
+++ b/apps/web/src/helpers/datetime/getTimeAddedNDay.test.ts
@@ -1,0 +1,17 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import getTimeAddedNDay from "./getTimeAddedNDay";
+
+describe("getTimeAddedNDay", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("adds days in UTC", () => {
+    vi.setSystemTime(new Date("2023-05-05T00:00:00Z"));
+    expect(getTimeAddedNDay(7)).toBe("2023-05-12T00:00:00Z");
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for datetime formatting helpers

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6845333ee8808330a0e6df7c8194188e