### PR TITLE
Add tests for middleware rewrites

### DIFF
--- a/apps/web/functions/_middleware.test.ts
+++ b/apps/web/functions/_middleware.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { onRequest } from "./_middleware";
+
+const createResponse = () =>
+  new Response("ok", { status: 200, headers: { x: "y" } });
+
+const stubFetch = () => {
+  const fetchMock = vi.fn(async () => createResponse());
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+};
+
+const createContext = (url: string, ua = "") => {
+  const headers = new Headers();
+  if (ua) headers.set("user-agent", ua);
+  const request = new Request(url, { headers });
+  return { request, next: vi.fn() };
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("onRequest middleware", () => {
+  it("rewrites sitemap root", async () => {
+    const fetchMock = stubFetch();
+    const ctx = createContext("https://hey.xyz/sitemap.xml");
+
+    const res = await onRequest(ctx as any);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.hey.xyz/sitemap/all.xml",
+      expect.any(Object)
+    );
+    expect(res.headers.get("Cache-Control")).toContain("no-store");
+  });
+
+  it("rewrites sitemap paths", async () => {
+    const fetchMock = stubFetch();
+    const ctx = createContext("https://hey.xyz/sitemap/posts.xml");
+
+    await onRequest(ctx as any);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.hey.xyz/sitemap/posts.xml",
+      expect.any(Object)
+    );
+  });
+
+  it("rewrites og paths for bots", async () => {
+    const fetchMock = stubFetch();
+    const ctx = createContext("https://hey.xyz/posts/123", "Googlebot");
+
+    await onRequest(ctx as any);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.hey.xyz/og/posts/123",
+      expect.any(Object)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `_middleware.ts` to verify sitemap and OG rewrites

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68453343f49c8330ab1c88ac85bb022d