### PR TITLE
Add Prosekit helper tests

### DIFF
--- a/apps/web/src/helpers/prosekit/markdown.test.ts
+++ b/apps/web/src/helpers/prosekit/markdown.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { htmlFromMarkdown, markdownFromHTML } from "./markdown";
+
+describe("markdown", () => {
+  it("converts html to markdown", () => {
+    expect(markdownFromHTML("<p>Hello</p>")).toBe("Hello\n");
+  });
+
+  it("converts markdown to html", () => {
+    expect(htmlFromMarkdown("Hello")).toBe("<p>Hello</p>\n");
+  });
+
+  it("joins consecutive paragraphs", () => {
+    expect(markdownFromHTML("<p>A</p><p>B</p>")).toBe("A\nB\n");
+  });
+
+  it("keeps underscores unescaped", () => {
+    expect(markdownFromHTML("<p>hello_world</p>")).toBe("hello_world\n");
+  });
+});

--- a/apps/web/src/helpers/prosekit/markdownContent.test.ts
+++ b/apps/web/src/helpers/prosekit/markdownContent.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("prosekit/core", () => ({
+  htmlFromNode: vi.fn(() => "<p>html</p>"),
+  nodeFromHTML: vi.fn(() => ({ content: "node" }))
+}));
+vi.mock("prosekit/extensions/list", () => ({ ListDOMSerializer: {} }));
+
+import { htmlFromNode, nodeFromHTML } from "prosekit/core";
+import * as markdown from "./markdown";
+import { getMarkdownContent, setMarkdownContent } from "./markdownContent";
+
+describe("markdownContent", () => {
+  it("returns empty string when not mounted", () => {
+    expect(getMarkdownContent({ mounted: false } as any)).toBe("");
+  });
+
+  it("retrieves markdown from editor", () => {
+    const state = { doc: {} } as any;
+    const editor = { mounted: true, view: { state } } as any;
+    const result = getMarkdownContent(editor);
+    expect(htmlFromNode).toHaveBeenCalledWith(state.doc, { DOMSerializer: {} });
+    expect(result).toBe(markdown.markdownFromHTML("<p>html</p>"));
+  });
+
+  it("sets markdown content", () => {
+    const replaceWith = vi.fn(() => "tr" as any);
+    const state = {
+      doc: { content: { size: 1 } },
+      schema: {},
+      tr: { replaceWith }
+    } as any;
+    const dispatch = vi.fn();
+    const editor = { mounted: true, view: { state, dispatch } } as any;
+    const spy = vi.spyOn(markdown, "htmlFromMarkdown");
+    setMarkdownContent(editor, "md");
+    expect(spy).toHaveBeenCalledWith("md");
+    expect(nodeFromHTML).toHaveBeenCalledWith(markdown.htmlFromMarkdown("md"), {
+      schema: state.schema
+    });
+    expect(replaceWith).toHaveBeenCalledWith(0, state.doc.content.size, "node");
+    expect(dispatch).toHaveBeenCalledWith("tr");
+  });
+});

--- a/apps/web/src/helpers/prosekit/rehypeJoinParagraph.test.ts
+++ b/apps/web/src/helpers/prosekit/rehypeJoinParagraph.test.ts
@@ -1,0 +1,27 @@
+import rehypeParse from "rehype-parse";
+import { unified } from "unified";
+import { describe, expect, it } from "vitest";
+import { rehypeJoinParagraph } from "./rehypeJoinParagraph";
+
+describe("rehypeJoinParagraph", () => {
+  it("joins adjacent paragraphs", () => {
+    const processor = unified()
+      .use(rehypeParse, { fragment: true })
+      .use(rehypeJoinParagraph);
+    const root = processor.parse("<p>A</p><p>B</p>");
+    const result = processor.runSync(root) as any;
+    expect(result.children).toHaveLength(1);
+    const p = result.children[0] as any;
+    expect(p.tagName).toBe("p");
+    expect(p.children[1].tagName).toBe("br");
+  });
+
+  it("ignores empty paragraphs", () => {
+    const processor = unified()
+      .use(rehypeParse, { fragment: true })
+      .use(rehypeJoinParagraph);
+    const root = processor.parse("<p>A</p><p></p><p>B</p>");
+    const result = processor.runSync(root) as any;
+    expect(result.children).toHaveLength(3);
+  });
+});

--- a/apps/web/src/helpers/prosekit/remarkBreakHandler.test.ts
+++ b/apps/web/src/helpers/prosekit/remarkBreakHandler.test.ts
@@ -1,0 +1,23 @@
+import { defaultHandlers } from "mdast-util-to-markdown";
+import { describe, expect, it, vi } from "vitest";
+import { customBreakHandler } from "./remarkBreakHandler";
+
+vi.mock("mdast-util-to-markdown", () => ({
+  defaultHandlers: { break: vi.fn() }
+}));
+
+describe("customBreakHandler", () => {
+  it("replaces default break output", () => {
+    (defaultHandlers.break as any).mockReturnValue("\\\n");
+    expect(
+      customBreakHandler({} as any, null as any, null as any, null as any)
+    ).toBe("\n");
+  });
+
+  it("passes through other output", () => {
+    (defaultHandlers.break as any).mockReturnValue("x");
+    expect(
+      customBreakHandler({} as any, null as any, null as any, null as any)
+    ).toBe("x");
+  });
+});

--- a/apps/web/src/helpers/prosekit/remarkLinkProtocol.test.ts
+++ b/apps/web/src/helpers/prosekit/remarkLinkProtocol.test.ts
@@ -1,0 +1,27 @@
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import { unified } from "unified";
+import { describe, expect, it } from "vitest";
+import { remarkLinkProtocol } from "./remarkLinkProtocol";
+
+describe("remarkLinkProtocol", () => {
+  it("adds https to bare links", () => {
+    const result = unified()
+      .use(remarkParse)
+      .use(remarkLinkProtocol)
+      .use(remarkStringify)
+      .processSync("[example.com](example.com)")
+      .toString();
+    expect(result).toBe("<https://example.com>\n");
+  });
+
+  it("keeps links with protocol", () => {
+    const result = unified()
+      .use(remarkParse)
+      .use(remarkLinkProtocol)
+      .use(remarkStringify)
+      .processSync("[link](http://example.com)")
+      .toString();
+    expect(result).toBe("[link](http://example.com)\n");
+  });
+});


### PR DESCRIPTION
## Summary
- test markdown helpers
- test markdownContent conversion
- test custom break handler
- test rehype paragraph joining plugin
- test remark link protocol

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6845333d0e848330b3ea8efd63f3efe4