### PR TITLE
Add tests for getFileFromDataURL helper

### DIFF
--- a/apps/web/src/helpers/getFileFromDataURL.test.ts
+++ b/apps/web/src/helpers/getFileFromDataURL.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import getFileFromDataURL from "./getFileFromDataURL";
+
+class MockCanvas {
+  width = 0;
+  height = 0;
+  ctx = { drawImage: vi.fn() };
+  getContext() {
+    return this.ctx;
+  }
+  toBlob(callback: (blob: Blob | null) => void) {
+    callback(new Blob(["x"], { type: "image/png" }));
+  }
+}
+
+class MockImage {
+  width = 10;
+  height = 10;
+  crossOrigin = "";
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  set src(value: string) {
+    setTimeout(() => {
+      if (value === "error") {
+        this.onerror?.();
+      } else {
+        this.onload?.();
+      }
+    }, 0);
+  }
+}
+
+describe("getFileFromDataURL", () => {
+  beforeEach(() => {
+    (global as any).Image = MockImage;
+    (global as any).document = {
+      createElement: (tag: string) => {
+        if (tag === "canvas") {
+          return new MockCanvas();
+        }
+        return {};
+      }
+    };
+  });
+
+  afterEach(() => {
+    (global as any).Image = undefined;
+    (global as any).document = undefined;
+  });
+
+  it("converts data URL to File", async () => {
+    const file = await new Promise<File | null>((resolve) => {
+      getFileFromDataURL("data:image/png;base64,AA", "test.png", resolve);
+    });
+    expect(file).toBeInstanceOf(File);
+    expect(file?.name).toBe("test.png");
+  });
+
+  it("returns null when image fails to load", async () => {
+    const cb = vi.fn();
+    await new Promise<void>((resolve) => {
+      getFileFromDataURL("error", "test.png", (file) => {
+        cb(file);
+        resolve();
+      });
+    });
+    expect(cb).toHaveBeenCalledWith(null);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `getFileFromDataURL`

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6845360c48c0833097388a84b4b1b01a