### PR TITLE
Add isRepost null and Mirror tests

### DIFF
--- a/packages/helpers/postHelpers.test.ts
+++ b/packages/helpers/postHelpers.test.ts
@@ -8,4 +8,10 @@ describe("isRepost", () => {
   it("returns false otherwise", () => {
     expect(isRepost({ __typename: "Post" } as any)).toBe(false);
   });
+  it("returns false when argument is null", () => {
+    expect(isRepost(null)).toBe(false);
+  });
+  it("returns false for other typenames", () => {
+    expect(isRepost({ __typename: "Mirror" } as any)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- expand postHelpers tests for `isRepost`

## Testing
- `pnpm test` *(fails: uploadMetadata test)*
- `pnpm biome:check`
- `pnpm typecheck` *(fails: Form.tsx type error)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68453dbef7c4833099bd2c07e452e6c2