### PR TITLE
Add non-json payload test for parseJwt

### DIFF
--- a/packages/helpers/parseJwt.test.ts
+++ b/packages/helpers/parseJwt.test.ts
@@ -35,4 +35,14 @@ describe("parseJwt", () => {
       act: { sub: "" }
     });
   });
+
+  it("returns defaults for non-json payload", () => {
+    const encoded = Buffer.from("plain text").toString("base64");
+    expect(parseJwt(`a.${encoded}.b`)).toEqual({
+      sub: "",
+      exp: 0,
+      sid: "",
+      act: { sub: "" }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- extend parseJwt tests to handle non-JSON payloads

## Testing
- `pnpm test` *(fails: uploadMetadata test requires network)*
- `pnpm biome:check`
- `pnpm typecheck` *(fails: apps/web type errors)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68453dc06bac83309f6d2972f267cb3b