### PR TITLE
Add tests for getPostData

### DIFF
--- a/packages/helpers/getPostData.test.ts
+++ b/packages/helpers/getPostData.test.ts
@@ -46,6 +46,46 @@ describe("getPostData", () => {
     });
   });
 
+  it("handles video metadata", () => {
+    const meta = {
+      __typename: "VideoMetadata",
+      content: "video",
+      video: { item: ipfs, cover: ipfs },
+      attachments: []
+    } as any;
+
+    expect(getPostData(meta)).toEqual({
+      asset: { cover: sanitized, type: "Video", uri: sanitized },
+      content: "video"
+    });
+  });
+
+  it("handles article metadata", () => {
+    const meta = {
+      __typename: "ArticleMetadata",
+      content: "article",
+      attachments: [{ __typename: "MediaImage", item: ipfs }]
+    } as any;
+
+    expect(getPostData(meta)).toEqual({
+      attachments: [{ type: "Image", uri: sanitized }],
+      content: "article"
+    });
+  });
+
+  it("handles undefined attachments", () => {
+    const meta = {
+      __typename: "ArticleMetadata",
+      content: "attachments none",
+      attachments: undefined
+    } as any;
+
+    expect(getPostData(meta)).toEqual({
+      attachments: [],
+      content: "attachments none"
+    });
+  });
+
   it("returns null for unknown type", () => {
     expect(getPostData({ __typename: "Unknown" } as any)).toBeNull();
   });


### PR DESCRIPTION
## Summary
- cover VideoMetadata cases
- test ArticleMetadata handling
- ensure undefined attachments are safe

## Testing
- `pnpm test` *(fails: Something went wrong)*
- `pnpm biome:check`
- `pnpm typecheck` *(fails: Form.tsx TS error)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68453dc8812483308d22dfb9db9c04a0