### PR TITLE
Add additional imageKit tests

### DIFF
--- a/packages/helpers/imageKit.test.ts
+++ b/packages/helpers/imageKit.test.ts
@@ -19,4 +19,18 @@ describe("imageKit", () => {
       `${LENS_MEDIA_SNAPSHOT_URL}/tr:w-100/file.jpg`
     );
   });
+
+  it("preserves query string in snapshot url", () => {
+    const url = `${LENS_MEDIA_SNAPSHOT_URL}/path/file.jpg?ver=1`;
+    expect(imageKit(url, "tr:w-100")).toBe(
+      `${LENS_MEDIA_SNAPSHOT_URL}/tr:w-100/file.jpg?ver=1`
+    );
+  });
+
+  it("handles trailing slash in snapshot url", () => {
+    const url = `${LENS_MEDIA_SNAPSHOT_URL}/path/file.jpg/`;
+    expect(imageKit(url, "tr:w-100")).toBe(
+      `${LENS_MEDIA_SNAPSHOT_URL}/tr:w-100/`
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add snapshot URL cases with query strings and trailing slashes to `imageKit.test.ts`

## Testing
- `pnpm biome:check`
- `pnpm typecheck` *(fails: Form.tsx no overload matches this call)*
- `pnpm build`
- `pnpm test` *(fails: uploadMetadata test)*

------
https://chatgpt.com/codex/tasks/task_e_68453dc65e348330bde9b24f98abe49d