### PR TITLE
Add getAvatar edge case tests

### DIFF
--- a/packages/helpers/getAvatar.test.ts
+++ b/packages/helpers/getAvatar.test.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_AVATAR,
   LENS_MEDIA_SNAPSHOT_URL,
+  STORAGE_NODE_URL,
   TRANSFORMS
 } from "@hey/data/constants";
 import { describe, expect, it } from "vitest";
@@ -37,5 +38,16 @@ describe("getAvatar", () => {
     expect(result).toBe(
       `${LENS_MEDIA_SNAPSHOT_URL}/${TRANSFORMS.AVATAR_TINY}/file.png`
     );
+  });
+
+  it("returns default for malformed url", () => {
+    const avatar = getAvatar({ metadata: { picture: "ftp://bad" } });
+    expect(avatar).toBe(DEFAULT_AVATAR);
+  });
+
+  it("sanitizes lens uri avatar", () => {
+    const lensUri = "lens://abcdef";
+    const avatar = getAvatar({ metadata: { picture: lensUri } });
+    expect(avatar).toBe(`${STORAGE_NODE_URL}/abcdef`);
   });
 });

--- a/packages/helpers/getAvatar.ts
+++ b/packages/helpers/getAvatar.ts
@@ -13,7 +13,13 @@ const getAvatar = (
   const avatarUrl =
     entity?.metadata?.picture || entity?.metadata?.icon || DEFAULT_AVATAR;
 
-  return imageKit(sanitizeDStorageUrl(avatarUrl), namedTransform);
+  const sanitized = sanitizeDStorageUrl(avatarUrl);
+
+  if (!sanitized || !/^https?:\/\//.test(sanitized)) {
+    return DEFAULT_AVATAR;
+  }
+
+  return imageKit(sanitized, namedTransform);
 };
 
 export default getAvatar;


### PR DESCRIPTION
## Summary
- add tests for malformed and lens URLs
- handle malformed URLs in `getAvatar`

## Testing
- `pnpm test` *(fails: uploadMetadata)*
- `pnpm biome:check`
- `pnpm typecheck` *(fails: type errors in @hey/web)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68453dcb0bd88330b38bb89b639534f9