### PR TITLE
Add more getAccount unit tests

### DIFF
--- a/packages/helpers/getAccount.test.ts
+++ b/packages/helpers/getAccount.test.ts
@@ -58,4 +58,34 @@ describe("getAccount", () => {
       usernameWithPrefix: `#${formatted}`
     });
   });
+
+  it("handles username without lens namespace", () => {
+    const account: Account = {
+      owner: "0x1",
+      address,
+      metadata: { name: "Bob" },
+      username: { value: "bob", localName: "bob" }
+    };
+    expect(getAccount(account as any)).toEqual({
+      name: "Bob",
+      link: `/account/${address}`,
+      username: "bob",
+      usernameWithPrefix: "@bob"
+    });
+  });
+
+  it("falls back to username when sanitized name is empty", () => {
+    const account: Account = {
+      owner: "0x1",
+      address,
+      metadata: { name: "✓" },
+      username: { value: `${LENS_NAMESPACE}charlie`, localName: "charlie" }
+    };
+    expect(getAccount(account as any)).toEqual({
+      name: "charlie",
+      link: "/u/charlie",
+      username: "charlie",
+      usernameWithPrefix: "@charlie"
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- expand `getAccount.test` to cover username without lens namespace
- test fallback when `metadata.name` sanitizes to empty string

## Testing
- `pnpm biome:check`
- `pnpm test` *(fails: ERR_REQUIRE_ESM for apps/web)*
- `pnpm typecheck` *(fails: type errors in apps/web)*
- `pnpm build` *(fails: VITE_IS_PRODUCTION undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68453dcc6c7c8330a8450a95abdefc53