### PR TITLE
Add test for escapeHtml single quote

### DIFF
--- a/packages/helpers/escapeHtml.test.ts
+++ b/packages/helpers/escapeHtml.test.ts
@@ -10,6 +10,10 @@ describe("escapeHtml", () => {
     expect(escapeHtml('"Tom & Jerry"')).toBe("&quot;Tom &amp; Jerry&quot;");
   });
 
+  it("escapes single quotes", () => {
+    expect(escapeHtml("Tom's post")).toBe("Tom&#39;s post");
+  });
+
   it("handles null or undefined", () => {
     expect(escapeHtml(undefined)).toBe("");
     expect(escapeHtml(null)).toBe("");


### PR DESCRIPTION
## Summary
- cover escaping of single quotes in `escapeHtml`

## Testing
- `pnpm test` *(fails: uploadMetadata test fails)*
- `pnpm biome:check`
- `pnpm typecheck` *(fails: apps/web type errors)*
- `pnpm build` *(fails: build error)*

------
https://chatgpt.com/codex/tasks/task_e_68453dd0b4f88330b70ce7699a80e666