### PR TITLE
Add paymaster edge case tests

### DIFF
--- a/packages/helpers/selfFundedTransactionData.test.ts
+++ b/packages/helpers/selfFundedTransactionData.test.ts
@@ -22,4 +22,48 @@ describe("selfFundedTransactionData", () => {
       value: 5n
     });
   });
+
+  it("ignores null paymaster params", () => {
+    const raw = {
+      data: "0x",
+      gasLimit: 1,
+      maxFeePerGas: 2,
+      maxPriorityFeePerGas: 3,
+      nonce: 4,
+      to: "0x1",
+      value: 5,
+      customData: { paymasterParams: null }
+    } as any;
+    expect(selfFundedTransactionData(raw)).toEqual({
+      data: "0x",
+      gas: 1n,
+      maxFeePerGas: 2n,
+      maxPriorityFeePerGas: 3n,
+      nonce: 4,
+      to: "0x1",
+      value: 5n
+    });
+  });
+
+  it("ignores missing paymasterInput", () => {
+    const raw = {
+      data: "0x",
+      gasLimit: 1,
+      maxFeePerGas: 2,
+      maxPriorityFeePerGas: 3,
+      nonce: 4,
+      to: "0x1",
+      value: 5,
+      customData: { paymasterParams: { paymaster: "p" } }
+    } as any;
+    expect(selfFundedTransactionData(raw)).toEqual({
+      data: "0x",
+      gas: 1n,
+      maxFeePerGas: 2n,
+      maxPriorityFeePerGas: 3n,
+      nonce: 4,
+      to: "0x1",
+      value: 5n
+    });
+  });
 });

--- a/packages/helpers/sponsoredTransactionData.test.ts
+++ b/packages/helpers/sponsoredTransactionData.test.ts
@@ -52,4 +52,52 @@ describe("sponsoredTransactionData", () => {
       value: 5n
     });
   });
+
+  it("handles null paymaster params", () => {
+    const raw = {
+      data: "0x",
+      gasLimit: 1,
+      maxFeePerGas: 2,
+      maxPriorityFeePerGas: 3,
+      nonce: 4,
+      to: "0x1",
+      value: 5,
+      customData: { paymasterParams: null }
+    } as any;
+    expect(sponsoredTransactionData(raw)).toEqual({
+      data: "0x",
+      gas: 1n,
+      maxFeePerGas: 2n,
+      maxPriorityFeePerGas: 3n,
+      nonce: 4,
+      paymaster: undefined,
+      paymasterInput: undefined,
+      to: "0x1",
+      value: 5n
+    });
+  });
+
+  it("handles missing paymasterInput", () => {
+    const raw = {
+      data: "0x",
+      gasLimit: 1,
+      maxFeePerGas: 2,
+      maxPriorityFeePerGas: 3,
+      nonce: 4,
+      to: "0x1",
+      value: 5,
+      customData: { paymasterParams: { paymaster: "p" } }
+    } as any;
+    expect(sponsoredTransactionData(raw)).toEqual({
+      data: "0x",
+      gas: 1n,
+      maxFeePerGas: 2n,
+      maxPriorityFeePerGas: 3n,
+      nonce: 4,
+      paymaster: "p",
+      paymasterInput: undefined,
+      to: "0x1",
+      value: 5n
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add extra test coverage for self-funded and sponsored transactions
  - handle null `paymasterParams`
  - handle missing `paymasterInput`

## Testing
- `pnpm test` *(fails: uploadMetadata test)*
- `pnpm biome:check`
- `pnpm typecheck` *(fails: apps/web typecheck)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68453dbb92b08330bbcd74ea77f62f77