### PR TITLE
Add URL regex test coverage

### DIFF
--- a/packages/data/regex.test.ts
+++ b/packages/data/regex.test.ts
@@ -56,6 +56,12 @@ describe("Regex", () => {
 
   it("matches urls", () => {
     expect(newRegex(Regex.url).test("https://example.com/path?x=1")).toBe(true);
+    expect(
+      newRegex(Regex.url).test("https://example.com/path/?q=1#section")
+    ).toBe(true);
+    expect(newRegex(Regex.url).test("https://xn--fsqu00a.xn--0zwm56d")).toBe(
+      true
+    );
     expect(newRegex(Regex.url).test("https://例子.测试")).toBe(true);
     expect(newRegex(Regex.url).test("ftp://example.com")).toBe(false);
     expect(newRegex(Regex.url).test("example.com")).toBe(false);


### PR DESCRIPTION
## Summary
- add additional URL regex tests including query/fragment and punycode domains

## Testing
- `pnpm test` *(fails: uploadMetadata test requires network)*
- `pnpm biome:check`
- `pnpm typecheck` *(fails: apps/web Form.tsx type errors)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68453db9ea5c83309ea48b76339153d7