### PR TITLE
Add OG route and cron job error tests

### DIFF
--- a/apps/api/src/routes/cron/guild/syncFollowersStandingToGuild.test.ts
+++ b/apps/api/src/routes/cron/guild/syncFollowersStandingToGuild.test.ts
@@ -31,4 +31,18 @@ describe("syncFollowersStandingToGuild", () => {
     });
     expect(result).toEqual({ success: true });
   });
+
+  it("returns success when no accounts are found", async () => {
+    (lensPg.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const ctx = { json: vi.fn((b: unknown) => b) } as unknown as Context;
+
+    const result = await syncFollowersStandingToGuild(ctx);
+
+    expect(syncAddressesToGuild).toHaveBeenCalledWith({
+      addresses: [],
+      roleId: 173474,
+      requirementId: 471279
+    });
+    expect(result).toEqual({ success: true });
+  });
 });

--- a/apps/api/src/routes/cron/guild/syncHQScoreAccountsToGuild.test.ts
+++ b/apps/api/src/routes/cron/guild/syncHQScoreAccountsToGuild.test.ts
@@ -31,4 +31,18 @@ describe("syncHQScoreAccountsToGuild", () => {
     });
     expect(result).toEqual({ success: true });
   });
+
+  it("returns success when no accounts are found", async () => {
+    (lensPg.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const ctx = { json: vi.fn((b: unknown) => b) } as unknown as Context;
+
+    const result = await syncHQScoreAccountsToGuild(ctx);
+
+    expect(syncAddressesToGuild).toHaveBeenCalledWith({
+      addresses: [],
+      roleId: 173446,
+      requirementId: 471245
+    });
+    expect(result).toEqual({ success: true });
+  });
 });

--- a/apps/api/src/routes/cron/guild/syncSubscribersToGuild.test.ts
+++ b/apps/api/src/routes/cron/guild/syncSubscribersToGuild.test.ts
@@ -31,4 +31,18 @@ describe("syncSubscribersToGuild", () => {
     });
     expect(result).toEqual({ success: true });
   });
+
+  it("returns success when no accounts are found", async () => {
+    (lensPg.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const ctx = { json: vi.fn((b: unknown) => b) } as unknown as Context;
+
+    const result = await syncSubscribersToGuild(ctx);
+
+    expect(syncAddressesToGuild).toHaveBeenCalledWith({
+      addresses: [],
+      roleId: 173026,
+      requirementId: 470539
+    });
+    expect(result).toEqual({ success: true });
+  });
 });

--- a/apps/api/src/routes/cron/removeExpiredSubscribers/index.test.ts
+++ b/apps/api/src/routes/cron/removeExpiredSubscribers/index.test.ts
@@ -47,4 +47,16 @@ describe("removeExpiredSubscribers", () => {
       hash: "hash"
     });
   });
+
+  it("returns success when no accounts are expired", async () => {
+    (lensPg.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const ctx = { json: vi.fn((b: unknown) => b) } as unknown as Context;
+
+    const result = await removeExpiredSubscribers(ctx);
+
+    expect(result).toEqual({
+      success: true,
+      message: "No expired subscribers"
+    });
+  });
 });

--- a/apps/api/src/routes/og/getGroup.test.ts
+++ b/apps/api/src/routes/og/getGroup.test.ts
@@ -1,8 +1,9 @@
+import apolloClient from "@hey/indexer/apollo/client";
 import type { Context } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import getGroup from "./getGroup";
-import "@hey/indexer/apollo/client";
 import "@hey/helpers/getAvatar";
+import defaultMetadata from "src/utils/defaultMetadata";
 import { getRedis, setRedis } from "src/utils/redis";
 
 vi.mock("@hey/indexer/apollo/client", () => ({
@@ -54,5 +55,38 @@ describe("og getGroup route", () => {
 
     expect(result).toBe("cached");
     expect(setRedis).not.toHaveBeenCalled();
+  });
+
+  it("returns default metadata when apollo query fails", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (
+      apolloClient.query as unknown as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new Error("fail"));
+    const html = vi.fn((b: string) => b);
+    const ctx = {
+      req: { param: vi.fn(() => ({ address: "0x1" })) },
+      html
+    } as unknown as Context;
+
+    const result = await getGroup(ctx);
+
+    expect(html).toHaveBeenCalledWith(defaultMetadata, 500);
+    expect(result).toBe(defaultMetadata);
+  });
+
+  it("handles redis errors gracefully", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("fail")
+    );
+    const html = vi.fn((b: string) => b);
+    const ctx = {
+      req: { param: vi.fn(() => ({ address: "0x1" })) },
+      html
+    } as unknown as Context;
+
+    const result = await getGroup(ctx);
+
+    expect(html).toHaveBeenCalledWith(defaultMetadata, 500);
+    expect(result).toBe(defaultMetadata);
   });
 });


### PR DESCRIPTION
## Summary
- add missing error handling cases for OG route tests
- check cron routes when no addresses are returned

## Testing
- `pnpm test` *(fails: uploadMetadata and typecheck issues)*
- `pnpm biome:check`
- `pnpm typecheck` *(fails: type errors in web package)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68453db206508330b14af11d255ef26f