### PR TITLE
Add formatAddress edge case tests

### DIFF
--- a/packages/helpers/formatAddress.test.ts
+++ b/packages/helpers/formatAddress.test.ts
@@ -19,4 +19,18 @@ describe("formatAddress", () => {
   it("lowercases invalid address", () => {
     expect(formatAddress("NOTanADDRESS")).toBe("notanaddress");
   });
+
+  it("handles slice size exceeding address length", () => {
+    expect(formatAddress(address, 100)).toBe(`${address}…${address}`);
+  });
+
+  it("handles negative slice size", () => {
+    expect(formatAddress(address, -1)).toBe(
+      "0x1234567890abcdef1234567890abcdef1234567…"
+    );
+  });
+
+  it("handles short ENS name gracefully", () => {
+    expect(formatAddress("A.ETH")).toBe("a.eth");
+  });
 });


### PR DESCRIPTION
## Summary
- test formatting when slice size exceeds address length
- test negative slice size handling
- test short ENS names

## Testing
- `pnpm test` *(fails: vitest error in apps/web)*
- `pnpm biome:check`
- `pnpm typecheck` *(fails: type errors in apps/web)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68453dce84c08330b6ab10f0eb1eb080