### PR TITLE
Switch to franc-min

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,7 +34,7 @@
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",
     "family": "^0.1.2",
-    "franc": "^6.2.0",
+    "franc-min": "^6.2.0",
     "hast": "^1.0.0",
     "mdast-util-to-markdown": "^2.1.2",
     "motion": "^12.16.0",

--- a/apps/web/src/components/Post/Translate.tsx
+++ b/apps/web/src/components/Post/Translate.tsx
@@ -4,7 +4,7 @@ import getPostData from "@hey/helpers/getPostData";
 import { isRepost } from "@hey/helpers/postHelpers";
 import type { AnyPostFragment } from "@hey/indexer";
 import { useMutation } from "@tanstack/react-query";
-import { franc } from "franc";
+import { franc } from "franc-min";
 import { useState } from "react";
 import Markup from "../Shared/Markup";
 import { Spinner } from "../Shared/UI";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,7 +171,7 @@ importers:
       family:
         specifier: ^0.1.2
         version: 0.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56))(wagmi@2.15.6(@tanstack/query-core@5.80.6)(@tanstack/react-query@5.80.6(react@19.1.0))(@types/react@19.1.6)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56))(zod@3.25.56))
-      franc:
+      franc-min:
         specifier: ^6.2.0
         version: 6.2.0
       hast:
@@ -3853,8 +3853,8 @@ packages:
       react-dom:
         optional: true
 
-  franc@6.2.0:
-    resolution: {integrity: sha512-rcAewP7PSHvjq7Kgd7dhj82zE071kX5B4W1M4ewYMf/P+i6YsDQmj62Xz3VQm9zyUzUXwhIde/wHLGCMrM+yGg==}
+  franc-min@6.2.0:
+    resolution: {integrity: sha512-1uDIEUSlUZgvJa2AKYR/dmJC66v/PvGQ9mWfI9nOr/kPpMFyvswK0gPXOwpYJYiYD008PpHLkGfG58SPjQJFxw==}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -11538,7 +11538,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  franc@6.2.0:
+  franc-min@6.2.0:
     dependencies:
       trigram-utils: 2.0.1
 


### PR DESCRIPTION
## Summary
- use `franc-min` instead of `franc` in the web app

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68454298e8a48330a8b462b86223bd10