### PR TITLE
Ensure refreshed access tokens reach non-GraphQL requests

### DIFF
--- a/apps/web/src/helpers/authLink.ts
+++ b/apps/web/src/helpers/authLink.ts
@@ -1,95 +1,6 @@
-import {
-  hydrateAuthTokens,
-  signIn,
-  signOut
-} from "@/store/persisted/useAuthStore";
+import { hydrateAuthTokens, signOut } from "@/store/persisted/useAuthStore";
 import { ApolloLink, fromPromise, toPromise } from "@apollo/client";
-import { LENS_API_URL } from "@hey/data/constants";
-import parseJwt from "@hey/helpers/parseJwt";
-import type { RefreshResult } from "@hey/indexer";
-
-const REFRESH_AUTHENTICATION_MUTATION = `
-  mutation Refresh($request: RefreshRequest!) {
-    refresh(request: $request) {
-      ... on AuthenticationTokens {
-        accessToken
-        refreshToken
-      }
-      __typename
-    }
-  }
-`;
-
-let refreshPromise: Promise<string> | null = null;
-
-const MAX_RETRIES = 5;
-
-const executeTokenRefresh = async (
-  refreshToken: string,
-  attempt = 0
-): Promise<string> => {
-  try {
-    const response = await fetch(LENS_API_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        operationName: "Refresh",
-        query: REFRESH_AUTHENTICATION_MUTATION,
-        variables: { request: { refreshToken } }
-      })
-    });
-
-    if (!response.ok) {
-      return await executeTokenRefresh(refreshToken, attempt + 1);
-    }
-
-    const { data } = await response.json();
-    const refreshResult = data?.refresh as RefreshResult;
-
-    if (!refreshResult) {
-      throw new Error("No response from refresh");
-    }
-
-    const { __typename } = refreshResult;
-
-    if (__typename === "AuthenticationTokens") {
-      const { accessToken: newAccessToken, refreshToken: newRefreshToken } =
-        refreshResult;
-
-      if (!newAccessToken || !newRefreshToken) {
-        throw new Error("Missing tokens in refresh response");
-      }
-
-      signIn({
-        accessToken: newAccessToken,
-        refreshToken: newRefreshToken
-      });
-
-      return newAccessToken;
-    }
-
-    if (__typename === "ForbiddenError") {
-      signOut();
-      throw new Error("Refresh token is invalid or expired");
-    }
-
-    if (attempt < MAX_RETRIES) {
-      return await executeTokenRefresh(refreshToken, attempt + 1);
-    }
-
-    throw new Error("Unknown error during token refresh");
-  } finally {
-    refreshPromise = null;
-  }
-};
-
-const refreshTokens = (refreshToken: string): Promise<string> => {
-  if (!refreshPromise) {
-    refreshPromise = executeTokenRefresh(refreshToken);
-  }
-
-  return refreshPromise;
-};
+import { isTokenExpiringSoon, refreshTokens } from "./tokenManager";
 
 const authLink = new ApolloLink((operation, forward) => {
   const { accessToken, refreshToken } = hydrateAuthTokens();
@@ -99,11 +10,7 @@ const authLink = new ApolloLink((operation, forward) => {
     return forward(operation);
   }
 
-  const tokenData = parseJwt(accessToken);
-  const bufferInMinutes = 5;
-  const isExpiringSoon =
-    tokenData?.exp &&
-    Date.now() >= tokenData.exp * 1000 - bufferInMinutes * 60 * 1000;
+  const isExpiringSoon = isTokenExpiringSoon(accessToken);
 
   if (!isExpiringSoon) {
     operation.setContext({

--- a/apps/web/src/helpers/fetcher.ts
+++ b/apps/web/src/helpers/fetcher.ts
@@ -1,6 +1,7 @@
 import { hydrateAuthTokens } from "@/store/persisted/useAuthStore";
 import { HEY_API_URL } from "@hey/data/constants";
 import type { Live, Oembed, Preferences, STS } from "@hey/types/api";
+import { isTokenExpiringSoon, refreshTokens } from "./tokenManager";
 
 interface ApiConfig {
   baseUrl?: string;
@@ -18,11 +19,22 @@ const fetchApi = async <T>(
   endpoint: string,
   options: RequestInit = {}
 ): Promise<T> => {
+  const { accessToken, refreshToken } = hydrateAuthTokens();
+  let token = accessToken;
+
+  if (token && refreshToken && isTokenExpiringSoon(token)) {
+    try {
+      token = await refreshTokens(refreshToken);
+    } catch {
+      // ignore refresh errors and use existing token
+    }
+  }
+
   const response = await fetch(`${config.baseUrl}${endpoint}`, {
     ...options,
     credentials: "include",
     headers: {
-      ...{ "X-Access-Token": hydrateAuthTokens().accessToken || "" },
+      ...{ "X-Access-Token": token || "" },
       ...config.headers
     }
   });

--- a/apps/web/src/helpers/tokenManager.ts
+++ b/apps/web/src/helpers/tokenManager.ts
@@ -1,0 +1,99 @@
+import { signIn, signOut } from "@/store/persisted/useAuthStore";
+import { LENS_API_URL } from "@hey/data/constants";
+import parseJwt from "@hey/helpers/parseJwt";
+import type { RefreshResult } from "@hey/indexer";
+
+const REFRESH_AUTHENTICATION_MUTATION = `
+  mutation Refresh($request: RefreshRequest!) {
+    refresh(request: $request) {
+      ... on AuthenticationTokens {
+        accessToken
+        refreshToken
+      }
+      __typename
+    }
+  }
+`;
+
+let refreshPromise: Promise<string> | null = null;
+const MAX_RETRIES = 5;
+
+const executeTokenRefresh = async (
+  refreshToken: string,
+  attempt = 0
+): Promise<string> => {
+  try {
+    const response = await fetch(LENS_API_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        operationName: "Refresh",
+        query: REFRESH_AUTHENTICATION_MUTATION,
+        variables: { request: { refreshToken } }
+      })
+    });
+
+    if (!response.ok) {
+      return await executeTokenRefresh(refreshToken, attempt + 1);
+    }
+
+    const { data } = await response.json();
+    const refreshResult = data?.refresh as RefreshResult;
+
+    if (!refreshResult) {
+      throw new Error("No response from refresh");
+    }
+
+    const { __typename } = refreshResult;
+
+    if (__typename === "AuthenticationTokens") {
+      const { accessToken: newAccessToken, refreshToken: newRefreshToken } =
+        refreshResult;
+
+      if (!newAccessToken || !newRefreshToken) {
+        throw new Error("Missing tokens in refresh response");
+      }
+
+      signIn({
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken
+      });
+
+      return newAccessToken;
+    }
+
+    if (__typename === "ForbiddenError") {
+      signOut();
+      throw new Error("Refresh token is invalid or expired");
+    }
+
+    if (attempt < MAX_RETRIES) {
+      return await executeTokenRefresh(refreshToken, attempt + 1);
+    }
+
+    throw new Error("Unknown error during token refresh");
+  } finally {
+    refreshPromise = null;
+  }
+};
+
+export const refreshTokens = (refreshToken: string): Promise<string> => {
+  if (!refreshPromise) {
+    refreshPromise = executeTokenRefresh(refreshToken);
+  }
+
+  return refreshPromise;
+};
+
+export const isTokenExpiringSoon = (accessToken: string | null): boolean => {
+  if (!accessToken) {
+    return false;
+  }
+
+  const tokenData = parseJwt(accessToken);
+  const bufferInMinutes = 5;
+  return (
+    !!tokenData.exp &&
+    Date.now() >= tokenData.exp * 1000 - bufferInMinutes * 60 * 1000
+  );
+};


### PR DESCRIPTION
## Summary
- share token refresh logic via `tokenManager`
- check token expiry in the generic fetcher
- simplify `authLink` to use the shared helpers

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68457863cc1c8330b94fcf59006d0506