### PR TITLE
Reduce useEffect duplication

### DIFF
--- a/apps/web/src/components/Bookmarks/BookmarksFeed.tsx
+++ b/apps/web/src/components/Bookmarks/BookmarksFeed.tsx
@@ -1,6 +1,7 @@
 import SinglePost from "@/components/Post/SinglePost";
 import PostsShimmer from "@/components/Shared/Shimmer/PostsShimmer";
 import { Card, EmptyState, ErrorMessage } from "@/components/Shared/UI";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { BookmarkIcon } from "@heroicons/react/24/outline";
 import {
   type MainContentFocus,
@@ -8,7 +9,6 @@ import {
   type PostBookmarksRequest,
   usePostBookmarksQuery
 } from "@hey/indexer";
-import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { WindowVirtualizer } from "virtua";
 
 interface BookmarksFeedProps {
@@ -16,7 +16,6 @@ interface BookmarksFeedProps {
 }
 
 const BookmarksFeed = ({ focus }: BookmarksFeedProps) => {
-
   const request: PostBookmarksRequest = {
     pageSize: PageSize.Fifty,
     ...(focus && { filter: { metadata: { mainContentFocus: [focus] } } })

--- a/apps/web/src/components/Bookmarks/BookmarksFeed.tsx
+++ b/apps/web/src/components/Bookmarks/BookmarksFeed.tsx
@@ -8,8 +8,7 @@ import {
   type PostBookmarksRequest,
   usePostBookmarksQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
-import { useEffect } from "react";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { WindowVirtualizer } from "virtua";
 
 interface BookmarksFeedProps {
@@ -17,11 +16,6 @@ interface BookmarksFeedProps {
 }
 
 const BookmarksFeed = ({ focus }: BookmarksFeedProps) => {
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: PostBookmarksRequest = {
     pageSize: PageSize.Fifty,
@@ -43,12 +37,7 @@ const BookmarksFeed = ({ focus }: BookmarksFeedProps) => {
       });
     }
   };
-
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <PostsShimmer />;
@@ -73,7 +62,7 @@ const BookmarksFeed = ({ focus }: BookmarksFeedProps) => {
         {posts.map((post) => (
           <SinglePost key={post.id} post={post} />
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </WindowVirtualizer>
     </Card>
   );

--- a/apps/web/src/components/Comment/CommentFeed.tsx
+++ b/apps/web/src/components/Comment/CommentFeed.tsx
@@ -12,8 +12,7 @@ import {
   type ReferencedPostFragment,
   usePostReferencesQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
-import { useEffect } from "react";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { WindowVirtualizer } from "virtua";
 
 interface CommentFeedProps {
@@ -22,11 +21,6 @@ interface CommentFeedProps {
 
 const CommentFeed = ({ postId }: CommentFeedProps) => {
   const { showHiddenComments } = useHiddenCommentFeedStore();
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: PostReferencesRequest = {
     pageSize: PageSize.Fifty,
@@ -55,12 +49,7 @@ const CommentFeed = ({ postId }: CommentFeedProps) => {
       });
     }
   };
-
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <PostsShimmer />;
@@ -93,7 +82,7 @@ const CommentFeed = ({ postId }: CommentFeedProps) => {
         {filteredComments.map((comment) => (
           <SinglePost key={comment.id} post={comment} showType={false} />
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </WindowVirtualizer>
     </Card>
   );

--- a/apps/web/src/components/Comment/CommentFeed.tsx
+++ b/apps/web/src/components/Comment/CommentFeed.tsx
@@ -2,6 +2,7 @@ import { useHiddenCommentFeedStore } from "@/components/Post";
 import SinglePost from "@/components/Post/SinglePost";
 import PostsShimmer from "@/components/Shared/Shimmer/PostsShimmer";
 import { Card, EmptyState, ErrorMessage } from "@/components/Shared/UI";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { ChatBubbleLeftIcon } from "@heroicons/react/24/outline";
 import {
   PageSize,
@@ -12,7 +13,6 @@ import {
   type ReferencedPostFragment,
   usePostReferencesQuery
 } from "@hey/indexer";
-import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { WindowVirtualizer } from "virtua";
 
 interface CommentFeedProps {

--- a/apps/web/src/components/Comment/NoneRelevantFeed.tsx
+++ b/apps/web/src/components/Comment/NoneRelevantFeed.tsx
@@ -1,6 +1,7 @@
 import { useHiddenCommentFeedStore } from "@/components/Post";
 import SinglePost from "@/components/Post/SinglePost";
 import { Card, StackedAvatars } from "@/components/Shared/UI";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 import { TRANSFORMS } from "@hey/data/constants";
 import getAvatar from "@hey/helpers/getAvatar";
@@ -13,7 +14,6 @@ import {
   type ReferencedPostFragment,
   usePostReferencesQuery
 } from "@hey/indexer";
-import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { useState } from "react";
 import { WindowVirtualizer } from "virtua";
 

--- a/apps/web/src/components/Comment/NoneRelevantFeed.tsx
+++ b/apps/web/src/components/Comment/NoneRelevantFeed.tsx
@@ -13,8 +13,8 @@ import {
   type ReferencedPostFragment,
   usePostReferencesQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
-import { useEffect, useState } from "react";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
+import { useState } from "react";
 import { WindowVirtualizer } from "virtua";
 
 interface NoneRelevantFeedProps {
@@ -24,11 +24,6 @@ interface NoneRelevantFeedProps {
 const NoneRelevantFeed = ({ postId }: NoneRelevantFeedProps) => {
   const { showHiddenComments } = useHiddenCommentFeedStore();
   const [showMore, setShowMore] = useState(false);
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: PostReferencesRequest = {
     pageSize: PageSize.Fifty,
@@ -58,12 +53,7 @@ const NoneRelevantFeed = ({ postId }: NoneRelevantFeedProps) => {
       });
     }
   };
-
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (totalComments === 0) {
     return null;
@@ -102,7 +92,7 @@ const NoneRelevantFeed = ({ postId }: NoneRelevantFeedProps) => {
             {filteredComments.map((comment) => (
               <SinglePost key={comment.id} post={comment} showType={false} />
             ))}
-            {hasMore && <span ref={ref} />}
+            {hasMore && <span ref={loadMoreRef} />}
           </WindowVirtualizer>
         </Card>
       ) : null}

--- a/apps/web/src/components/Group/GroupFeed.tsx
+++ b/apps/web/src/components/Group/GroupFeed.tsx
@@ -1,6 +1,7 @@
 import SinglePost from "@/components/Post/SinglePost";
 import PostsShimmer from "@/components/Shared/Shimmer/PostsShimmer";
 import { Card, EmptyState, ErrorMessage } from "@/components/Shared/UI";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { ChatBubbleBottomCenterIcon } from "@heroicons/react/24/outline";
 import {
   PageSize,
@@ -8,7 +9,6 @@ import {
   type PostsRequest,
   usePostsQuery
 } from "@hey/indexer";
-import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { WindowVirtualizer } from "virtua";
 
 interface GroupFeedProps {
@@ -16,7 +16,6 @@ interface GroupFeedProps {
 }
 
 const GroupFeed = ({ feed }: GroupFeedProps) => {
-
   const request: PostsRequest = {
     filter: { feeds: [{ feed }] },
     pageSize: PageSize.Fifty

--- a/apps/web/src/components/Group/GroupFeed.tsx
+++ b/apps/web/src/components/Group/GroupFeed.tsx
@@ -8,8 +8,7 @@ import {
   type PostsRequest,
   usePostsQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
-import { useEffect } from "react";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { WindowVirtualizer } from "virtua";
 
 interface GroupFeedProps {
@@ -17,11 +16,6 @@ interface GroupFeedProps {
 }
 
 const GroupFeed = ({ feed }: GroupFeedProps) => {
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: PostsRequest = {
     filter: { feeds: [{ feed }] },
@@ -44,12 +38,7 @@ const GroupFeed = ({ feed }: GroupFeedProps) => {
       });
     }
   };
-
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <PostsShimmer />;
@@ -81,7 +70,7 @@ const GroupFeed = ({ feed }: GroupFeedProps) => {
         {filteredPosts.map((post) => (
           <SinglePost key={post.id} post={post} />
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </WindowVirtualizer>
     </Card>
   );

--- a/apps/web/src/components/Home/ForYou.tsx
+++ b/apps/web/src/components/Home/ForYou.tsx
@@ -1,6 +1,7 @@
 import SinglePost from "@/components/Post/SinglePost";
 import PostsShimmer from "@/components/Shared/Shimmer/PostsShimmer";
 import { Card, EmptyState, ErrorMessage } from "@/components/Shared/UI";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { LightBulbIcon } from "@heroicons/react/24/outline";
 import {
@@ -8,7 +9,6 @@ import {
   type PostsForYouRequest,
   usePostsForYouQuery
 } from "@hey/indexer";
-import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { WindowVirtualizer } from "virtua";
 
 const ForYou = () => {

--- a/apps/web/src/components/Home/ForYou.tsx
+++ b/apps/web/src/components/Home/ForYou.tsx
@@ -8,17 +8,11 @@ import {
   type PostsForYouRequest,
   usePostsForYouQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
-import { useEffect } from "react";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { WindowVirtualizer } from "virtua";
 
 const ForYou = () => {
   const { currentAccount } = useAccountStore();
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: PostsForYouRequest = {
     pageSize: PageSize.Fifty,
@@ -41,12 +35,7 @@ const ForYou = () => {
       });
     }
   };
-
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <PostsShimmer />;
@@ -78,7 +67,7 @@ const ForYou = () => {
         {filteredPosts.map((item) => (
           <SinglePost key={item.post.id} post={item.post} />
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </WindowVirtualizer>
     </Card>
   );

--- a/apps/web/src/hooks/useLoadMoreOnIntersect.tsx
+++ b/apps/web/src/hooks/useLoadMoreOnIntersect.tsx
@@ -1,0 +1,20 @@
+import { useIntersectionObserver } from "@uidotdev/usehooks";
+import { useEffect } from "react";
+
+const useLoadMoreOnIntersect = (onLoadMore: () => void) => {
+  const [ref, entry] = useIntersectionObserver({
+    threshold: 0,
+    root: null,
+    rootMargin: "0px"
+  });
+
+  useEffect(() => {
+    if (entry?.isIntersecting) {
+      onLoadMore();
+    }
+  }, [entry?.isIntersecting, onLoadMore]);
+
+  return ref;
+};
+
+export default useLoadMoreOnIntersect;


### PR DESCRIPTION
## Summary
- add `useLoadMoreOnIntersect` hook to encapsulate infinite scroll logic
- replace repeated `useEffect` intersection handlers in several feed components with the new hook

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm biome:check` *(fails: biome not found)*
- `pnpm typecheck` *(fails: ts errors, missing deps)*
- `pnpm build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a9965e648330ab415437141d276e