### PR TITLE
Fix avatar style in PostAccount

### DIFF
--- a/apps/web/src/components/Post/PostAccount.tsx
+++ b/apps/web/src/components/Post/PostAccount.tsx
@@ -74,7 +74,7 @@ const PostAccount = ({ account, group, post, timestamp }: PostAccountProps) => {
           <Image
             src={getAvatar(group, TRANSFORMS.AVATAR_TINY)}
             alt={group.metadata.name}
-            className="size-4 rounded"
+            className="size-4 rounded-sm"
           />
           <span className="truncate text-gray-500 dark:text-gray-200">
             {group.metadata.name}


### PR DESCRIPTION
## Summary
- tweak group avatar to use `rounded-sm` in `PostAccount`

## Testing
- `pnpm biome:check`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build` *(fails: comment annotation Rollup issue)*

------
https://chatgpt.com/codex/tasks/task_e_68467363e42c8330806e56c6350c5fe3