### PR TITLE
Refactor token operations modal

### DIFF
--- a/apps/web/src/components/Settings/Funds/TokenOperation.tsx
+++ b/apps/web/src/components/Settings/Funds/TokenOperation.tsx
@@ -1,0 +1,109 @@
+import { Button, Input, Modal } from "@/components/Shared/UI";
+import errorToast from "@/helpers/errorToast";
+import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
+import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
+import type { ApolloClientError } from "@hey/types/errors";
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface TokenOperationProps {
+  useMutationHook: any;
+  buildRequest: (value: string) => any;
+  resultKey: string;
+  buttonLabel: string;
+  title: string;
+  successMessage: string;
+  value: string;
+  refetch: () => void;
+}
+
+const TokenOperation = ({
+  useMutationHook,
+  buildRequest,
+  resultKey,
+  buttonLabel,
+  title,
+  successMessage,
+  value,
+  refetch
+}: TokenOperationProps) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [inputValue, setInputValue] = useState(value);
+  const handleTransactionLifecycle = useTransactionLifecycle();
+  const waitForTransactionToComplete = useWaitForTransactionToComplete();
+
+  const onCompleted = async (hash: string) => {
+    setShowModal(false);
+    await waitForTransactionToComplete(hash);
+    setIsSubmitting(false);
+    refetch();
+    toast.success(successMessage);
+  };
+
+  const onError = (error: ApolloClientError) => {
+    setIsSubmitting(false);
+    errorToast(error);
+  };
+
+  const [mutate] = useMutationHook({
+    onCompleted: async (data: any) => {
+      const result = data?.[resultKey];
+      if (result?.__typename === "InsufficientFunds") {
+        return onError({ message: "Insufficient funds" });
+      }
+
+      return await handleTransactionLifecycle({
+        transactionData: result,
+        onCompleted,
+        onError
+      });
+    },
+    onError
+  });
+
+  const handleSubmit = () => {
+    setIsSubmitting(true);
+
+    return mutate({ variables: { request: buildRequest(inputValue) } });
+  };
+
+  return (
+    <>
+      <Button
+        size="sm"
+        outline
+        onClick={() => setShowModal(true)}
+        disabled={isSubmitting || inputValue === "0"}
+        loading={isSubmitting}
+      >
+        {buttonLabel}
+      </Button>
+      <Modal title={title} show={showModal} onClose={() => setShowModal(false)}>
+        <div className="p-5">
+          <div className="mb-5 flex items-center gap-2">
+            <Input
+              type="number"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+            />
+            <Button size="lg" onClick={() => setInputValue(value)}>
+              Max
+            </Button>
+          </div>
+          <Button
+            className="w-full"
+            size="lg"
+            onClick={handleSubmit}
+            disabled={isSubmitting || !inputValue || inputValue === "0"}
+            loading={isSubmitting}
+          >
+            {title}
+          </Button>
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+export default TokenOperation;

--- a/apps/web/src/components/Settings/Funds/Unwrap.tsx
+++ b/apps/web/src/components/Settings/Funds/Unwrap.tsx
@@ -1,12 +1,6 @@
-import { Button, Input, Modal } from "@/components/Shared/UI";
-import errorToast from "@/helpers/errorToast";
-import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
-import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import { NATIVE_TOKEN_SYMBOL } from "@hey/data/constants";
 import { useUnwrapTokensMutation } from "@hey/indexer";
-import type { ApolloClientError } from "@hey/types/errors";
-import { useState } from "react";
-import { toast } from "sonner";
+import TokenOperation from "./TokenOperation";
 
 interface UnwrapProps {
   value: string;
@@ -14,87 +8,17 @@ interface UnwrapProps {
 }
 
 const Unwrap = ({ value, refetch }: UnwrapProps) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [showModal, setShowModal] = useState(false);
-  const [valueToUnwrap, setValueToUnwrap] = useState(value);
-  const handleTransactionLifecycle = useTransactionLifecycle();
-  const waitForTransactionToComplete = useWaitForTransactionToComplete();
-
-  const onCompleted = async (hash: string) => {
-    setShowModal(false);
-    await waitForTransactionToComplete(hash);
-    setIsSubmitting(false);
-    refetch();
-    toast.success("Unwrap Successful");
-  };
-
-  const onError = (error: ApolloClientError) => {
-    setIsSubmitting(false);
-    errorToast(error);
-  };
-
-  const [unwrapTokens] = useUnwrapTokensMutation({
-    onCompleted: async ({ unwrapTokens }) => {
-      if (unwrapTokens.__typename === "InsufficientFunds") {
-        return onError({ message: "Insufficient funds" });
-      }
-
-      return await handleTransactionLifecycle({
-        transactionData: unwrapTokens,
-        onCompleted,
-        onError
-      });
-    },
-    onError
-  });
-
-  const handleUnwrap = () => {
-    setIsSubmitting(true);
-
-    return unwrapTokens({
-      variables: { request: { amount: valueToUnwrap } }
-    });
-  };
-
   return (
-    <>
-      <Button
-        size="sm"
-        outline
-        onClick={() => setShowModal(true)}
-        disabled={isSubmitting || valueToUnwrap === "0"}
-        loading={isSubmitting}
-      >
-        Unwrap to {NATIVE_TOKEN_SYMBOL}
-      </Button>
-      <Modal
-        title="Unwrap"
-        show={showModal}
-        onClose={() => setShowModal(false)}
-      >
-        <div className="p-5">
-          <div className="mb-5 flex items-center gap-2">
-            <Input
-              type="number"
-              value={valueToUnwrap}
-              onChange={(e) => setValueToUnwrap(e.target.value)}
-            />
-            <Button size="lg" onClick={() => setValueToUnwrap(value)}>
-              Max
-            </Button>
-          </div>
-          <Button
-            className="w-full"
-            size="lg"
-            onClick={handleUnwrap}
-            disabled={isSubmitting || !valueToUnwrap || valueToUnwrap === "0"}
-            loading={isSubmitting}
-          >
-            Unwrap
-          </Button>
-        </div>
-      </Modal>
-    </>
+    <TokenOperation
+      useMutationHook={useUnwrapTokensMutation}
+      buildRequest={(amount) => ({ amount })}
+      resultKey="unwrapTokens"
+      buttonLabel={`Unwrap to ${NATIVE_TOKEN_SYMBOL}`}
+      title="Unwrap"
+      successMessage="Unwrap Successful"
+      value={value}
+      refetch={refetch}
+    />
   );
 };
 

--- a/apps/web/src/components/Settings/Funds/Withdraw.tsx
+++ b/apps/web/src/components/Settings/Funds/Withdraw.tsx
@@ -1,12 +1,6 @@
-import { Button, Input, Modal } from "@/components/Shared/UI";
-import errorToast from "@/helpers/errorToast";
-import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
-import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import { useWithdrawMutation } from "@hey/indexer";
-import type { ApolloClientError } from "@hey/types/errors";
-import { useState } from "react";
-import { toast } from "sonner";
 import type { Address } from "viem";
+import TokenOperation from "./TokenOperation";
 
 interface WithdrawProps {
   currency?: Address;
@@ -15,95 +9,19 @@ interface WithdrawProps {
 }
 
 const Withdraw = ({ currency, value, refetch }: WithdrawProps) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [showModal, setShowModal] = useState(false);
-  const [valueToWithdraw, setValueToWithdraw] = useState(value);
-  const handleTransactionLifecycle = useTransactionLifecycle();
-  const waitForTransactionToComplete = useWaitForTransactionToComplete();
-
-  const onCompleted = async (hash: string) => {
-    setShowModal(false);
-    await waitForTransactionToComplete(hash);
-    setIsSubmitting(false);
-    refetch();
-    toast.success("Withdrawal Successful");
-  };
-
-  const onError = (error: ApolloClientError) => {
-    setIsSubmitting(false);
-    errorToast(error);
-  };
-
-  const [withdraw] = useWithdrawMutation({
-    onCompleted: async ({ withdraw }) => {
-      if (withdraw.__typename === "InsufficientFunds") {
-        return onError({ message: "Insufficient funds" });
-      }
-
-      return await handleTransactionLifecycle({
-        transactionData: withdraw,
-        onCompleted,
-        onError
-      });
-    },
-    onError
-  });
-
-  const handleWithdraw = () => {
-    setIsSubmitting(true);
-
-    return withdraw({
-      variables: {
-        request: {
-          ...(currency
-            ? { erc20: { currency, value: valueToWithdraw } }
-            : { native: valueToWithdraw })
-        }
-      }
-    });
-  };
-
   return (
-    <>
-      <Button
-        size="sm"
-        outline
-        onClick={() => setShowModal(true)}
-        disabled={isSubmitting || valueToWithdraw === "0"}
-        loading={isSubmitting}
-      >
-        Withdraw
-      </Button>
-      <Modal
-        title="Withdraw"
-        show={showModal}
-        onClose={() => setShowModal(false)}
-      >
-        <div className="p-5">
-          <div className="mb-5 flex items-center gap-2">
-            <Input
-              type="number"
-              value={valueToWithdraw}
-              onChange={(e) => setValueToWithdraw(e.target.value)}
-            />
-            <Button size="lg" onClick={() => setValueToWithdraw(value)}>
-              Max
-            </Button>
-          </div>
-          <Button
-            className="w-full"
-            size="lg"
-            onClick={handleWithdraw}
-            disabled={
-              isSubmitting || !valueToWithdraw || valueToWithdraw === "0"
-            }
-            loading={isSubmitting}
-          >
-            Withdraw
-          </Button>
-        </div>
-      </Modal>
-    </>
+    <TokenOperation
+      useMutationHook={useWithdrawMutation}
+      buildRequest={(amount) =>
+        currency ? { erc20: { currency, value: amount } } : { native: amount }
+      }
+      resultKey="withdraw"
+      buttonLabel="Withdraw"
+      title="Withdraw"
+      successMessage="Withdrawal Successful"
+      value={value}
+      refetch={refetch}
+    />
   );
 };
 

--- a/apps/web/src/components/Settings/Funds/Wrap.tsx
+++ b/apps/web/src/components/Settings/Funds/Wrap.tsx
@@ -1,12 +1,6 @@
-import { Button, Input, Modal } from "@/components/Shared/UI";
-import errorToast from "@/helpers/errorToast";
-import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
-import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import { WRAPPED_NATIVE_TOKEN_SYMBOL } from "@hey/data/constants";
 import { useWrapTokensMutation } from "@hey/indexer";
-import type { ApolloClientError } from "@hey/types/errors";
-import { useState } from "react";
-import { toast } from "sonner";
+import TokenOperation from "./TokenOperation";
 
 interface WrapProps {
   value: string;
@@ -14,83 +8,17 @@ interface WrapProps {
 }
 
 const Wrap = ({ value, refetch }: WrapProps) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [showModal, setShowModal] = useState(false);
-  const [valueToWrap, setValueToWrap] = useState(value);
-  const handleTransactionLifecycle = useTransactionLifecycle();
-  const waitForTransactionToComplete = useWaitForTransactionToComplete();
-
-  const onCompleted = async (hash: string) => {
-    setShowModal(false);
-    await waitForTransactionToComplete(hash);
-    setIsSubmitting(false);
-    refetch();
-    toast.success("Wrap Successful");
-  };
-
-  const onError = (error: ApolloClientError) => {
-    setIsSubmitting(false);
-    errorToast(error);
-  };
-
-  const [wrapTokens] = useWrapTokensMutation({
-    onCompleted: async ({ wrapTokens }) => {
-      if (wrapTokens.__typename === "InsufficientFunds") {
-        return onError({ message: "Insufficient funds" });
-      }
-
-      return await handleTransactionLifecycle({
-        transactionData: wrapTokens,
-        onCompleted,
-        onError
-      });
-    },
-    onError
-  });
-
-  const handleWrap = () => {
-    setIsSubmitting(true);
-
-    return wrapTokens({
-      variables: { request: { amount: valueToWrap } }
-    });
-  };
-
   return (
-    <>
-      <Button
-        size="sm"
-        outline
-        onClick={() => setShowModal(true)}
-        disabled={isSubmitting || valueToWrap === "0"}
-        loading={isSubmitting}
-      >
-        Wrap to {WRAPPED_NATIVE_TOKEN_SYMBOL}
-      </Button>
-      <Modal title="Wrap" show={showModal} onClose={() => setShowModal(false)}>
-        <div className="p-5">
-          <div className="mb-5 flex items-center gap-2">
-            <Input
-              type="number"
-              value={valueToWrap}
-              onChange={(e) => setValueToWrap(e.target.value)}
-            />
-            <Button size="lg" onClick={() => setValueToWrap(value)}>
-              Max
-            </Button>
-          </div>
-          <Button
-            className="w-full"
-            size="lg"
-            onClick={handleWrap}
-            disabled={isSubmitting || !valueToWrap || valueToWrap === "0"}
-            loading={isSubmitting}
-          >
-            Wrap
-          </Button>
-        </div>
-      </Modal>
-    </>
+    <TokenOperation
+      useMutationHook={useWrapTokensMutation}
+      buildRequest={(amount) => ({ amount })}
+      resultKey="wrapTokens"
+      buttonLabel={`Wrap to ${WRAPPED_NATIVE_TOKEN_SYMBOL}`}
+      title="Wrap"
+      successMessage="Wrap Successful"
+      value={value}
+      refetch={refetch}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary
- add generic `TokenOperation` component to manage token operations
- simplify Wrap, Unwrap and Withdraw modals using the shared component

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d04864eac83309fb58032998ed320