### PR TITLE
Refactor image upload components

### DIFF
--- a/apps/web/src/components/Shared/AvatarUpload.tsx
+++ b/apps/web/src/components/Shared/AvatarUpload.tsx
@@ -1,18 +1,11 @@
 import ChooseFile from "@/components/Shared/ChooseFile";
 import { Button, Image, Modal } from "@/components/Shared/UI";
-import uploadCroppedImage, { readFile } from "@/helpers/accountPictureUtils";
 import cn from "@/helpers/cn";
-import getCroppedImg from "@/helpers/cropUtils";
-import errorToast from "@/helpers/errorToast";
-import { DEFAULT_AVATAR, TRANSFORMS } from "@hey/data/constants";
-import { Errors } from "@hey/data/errors";
-import imageKit from "@hey/helpers/imageKit";
+import useImageCropUpload from "@/hooks/useImageCropUpload";
+import { TRANSFORMS } from "@hey/data/constants";
 import sanitizeDStorageUrl from "@hey/helpers/sanitizeDStorageUrl";
-import type { ApolloClientError } from "@hey/types/errors";
-import type { ChangeEvent, SyntheticEvent } from "react";
-import { useState } from "react";
-import Cropper, { type Area } from "react-easy-crop";
-import { toast } from "sonner";
+import type { SyntheticEvent } from "react";
+import Cropper from "react-easy-crop";
 
 interface AvatarUploadProps {
   src: string;
@@ -21,61 +14,27 @@ interface AvatarUploadProps {
 }
 
 const AvatarUpload = ({ src, setSrc, isSmall = false }: AvatarUploadProps) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [pictureSrc, setPictureSrc] = useState(src);
-  const [showModal, setShowModal] = useState(false);
-  const [uploadedPicture, setUploadedPicture] = useState("");
-  const [uploading, setUploading] = useState(false);
-  const [area, setArea] = useState<Area | null>(null);
-  const [crop, setCrop] = useState({ x: 0, y: 0 });
-  const [zoom, setZoom] = useState(1);
-
-  const onError = (error: ApolloClientError) => {
-    setIsSubmitting(false);
-    errorToast(error);
-  };
-
-  const handleUploadAndSave = async () => {
-    try {
-      setUploading(true);
-      const croppedImage = await getCroppedImg(pictureSrc, area);
-
-      if (!croppedImage) {
-        return toast.error(Errors.SomethingWentWrong);
-      }
-
-      const decentralizedUrl = await uploadCroppedImage(croppedImage);
-      const dataUrl = croppedImage.toDataURL("image/png");
-
-      setSrc(decentralizedUrl);
-      setUploadedPicture(dataUrl);
-    } catch (error) {
-      onError(error);
-    } finally {
-      setArea(null);
-      setCrop({ x: 0, y: 0 });
-      setZoom(1);
-      setShowModal(false);
-      setUploading(false);
-    }
-  };
-
-  const onFileChange = async (evt: ChangeEvent<HTMLInputElement>) => {
-    const file = evt.target.files?.[0];
-    if (file) {
-      setPictureSrc(await readFile(file));
-      setShowModal(true);
-    }
-  };
-
-  const onCropComplete = (_: Area, croppedAreaPixels: Area) => {
-    setArea(croppedAreaPixels);
-  };
-
-  const pictureUrl = pictureSrc || DEFAULT_AVATAR;
-  const renderPictureUrl = pictureUrl
-    ? imageKit(sanitizeDStorageUrl(pictureUrl), TRANSFORMS.AVATAR_BIG)
-    : "";
+  const {
+    pictureSrc,
+    crop,
+    setCrop,
+    zoom,
+    setZoom,
+    showModal,
+    uploading,
+    uploadedPicture,
+    renderPictureUrl,
+    onFileChange,
+    onCropComplete,
+    handleUploadAndSave,
+    handleModalClose
+  } = useImageCropUpload({
+    src,
+    setSrc,
+    aspect: 1,
+    transform: TRANSFORMS.AVATAR_BIG,
+    label: "avatar"
+  });
 
   return (
     <>
@@ -95,14 +54,7 @@ const AvatarUpload = ({ src, setSrc, isSmall = false }: AvatarUploadProps) => {
         </div>
       </div>
       <Modal
-        onClose={
-          isSubmitting
-            ? undefined
-            : () => {
-                setPictureSrc("");
-                setShowModal(false);
-              }
-        }
+        onClose={handleModalClose}
         show={showModal}
         size="xs"
         title="Crop picture"
@@ -114,7 +66,7 @@ const AvatarUpload = ({ src, setSrc, isSmall = false }: AvatarUploadProps) => {
               image={pictureSrc}
               crop={crop}
               zoom={zoom}
-              aspect={5 / 5}
+              aspect={1}
               onCropChange={setCrop}
               onCropComplete={onCropComplete}
               onZoomChange={setZoom}

--- a/apps/web/src/hooks/useImageCropUpload.tsx
+++ b/apps/web/src/hooks/useImageCropUpload.tsx
@@ -1,0 +1,114 @@
+import uploadCroppedImage, { readFile } from "@/helpers/accountPictureUtils";
+import getCroppedImg from "@/helpers/cropUtils";
+import errorToast from "@/helpers/errorToast";
+import {
+  DEFAULT_AVATAR,
+  STATIC_IMAGES_URL,
+  type TRANSFORMS
+} from "@hey/data/constants";
+import { Errors } from "@hey/data/errors";
+import imageKit from "@hey/helpers/imageKit";
+import sanitizeDStorageUrl from "@hey/helpers/sanitizeDStorageUrl";
+import type { ApolloClientError } from "@hey/types/errors";
+import type { ChangeEvent } from "react";
+import { useState } from "react";
+import type { Area } from "react-easy-crop";
+import { toast } from "sonner";
+
+interface UseImageCropUploadProps {
+  src: string;
+  setSrc: (src: string) => void;
+  aspect: number;
+  transform: TRANSFORMS;
+  label: "avatar" | "cover";
+}
+
+const useImageCropUpload = ({
+  src,
+  setSrc,
+  aspect,
+  transform,
+  label
+}: UseImageCropUploadProps) => {
+  const [pictureSrc, setPictureSrc] = useState(src);
+  const [showModal, setShowModal] = useState(false);
+  const [uploadedPicture, setUploadedPicture] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [area, setArea] = useState<Area | null>(null);
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+
+  const onError = (error: ApolloClientError) => {
+    errorToast(error);
+  };
+
+  const handleUploadAndSave = async () => {
+    try {
+      setUploading(true);
+      const croppedImage = await getCroppedImg(pictureSrc, area);
+
+      if (!croppedImage) {
+        return toast.error(Errors.SomethingWentWrong);
+      }
+
+      const decentralizedUrl = await uploadCroppedImage(croppedImage);
+      const dataUrl = croppedImage.toDataURL("image/png");
+
+      setSrc(decentralizedUrl);
+      setUploadedPicture(dataUrl);
+    } catch (error) {
+      onError(error);
+    } finally {
+      setArea(null);
+      setCrop({ x: 0, y: 0 });
+      setZoom(1);
+      setShowModal(false);
+      setUploading(false);
+    }
+  };
+
+  const onFileChange = async (evt: ChangeEvent<HTMLInputElement>) => {
+    const file = evt.target.files?.[0];
+    if (file) {
+      setPictureSrc(await readFile(file));
+      setShowModal(true);
+    }
+  };
+
+  const onCropComplete = (_: Area, croppedAreaPixels: Area) => {
+    setArea(croppedAreaPixels);
+  };
+
+  const pictureUrl =
+    pictureSrc ||
+    (label === "avatar"
+      ? DEFAULT_AVATAR
+      : `${STATIC_IMAGES_URL}/patterns/2.svg`);
+  const renderPictureUrl = pictureUrl
+    ? imageKit(sanitizeDStorageUrl(pictureUrl), transform)
+    : "";
+
+  const handleModalClose = () => {
+    setPictureSrc("");
+    setShowModal(false);
+  };
+
+  return {
+    pictureSrc,
+    crop,
+    setCrop,
+    zoom,
+    setZoom,
+    showModal,
+    uploading,
+    uploadedPicture,
+    renderPictureUrl,
+    onFileChange,
+    onCropComplete,
+    handleUploadAndSave,
+    handleModalClose,
+    aspect
+  };
+};
+
+export default useImageCropUpload;


### PR DESCRIPTION
## Summary
- add `useImageCropUpload` hook for avatar/cover picture uploading
- simplify `AvatarUpload` by using `useImageCropUpload`
- simplify `CoverUpload` by using `useImageCropUpload`

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d04a40a508330b732ce758b9f4bb4