### PR TITLE
refactor: reuse intersect hook

### DIFF
--- a/apps/web/src/components/Groups/List.tsx
+++ b/apps/web/src/components/Groups/List.tsx
@@ -1,6 +1,7 @@
 import SingleGroup from "@/components/Shared/Group/SingleGroup";
 import GroupListShimmer from "@/components/Shared/Shimmer/GroupListShimmer";
 import { EmptyState, ErrorMessage } from "@/components/Shared/UI";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { UserGroupIcon } from "@heroicons/react/24/outline";
 import { GroupsFeedType } from "@hey/data/enums";
@@ -10,8 +11,6 @@ import {
   PageSize,
   useGroupsQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
-import { useEffect } from "react";
 import { WindowVirtualizer } from "virtua";
 
 interface ListProps {
@@ -20,11 +19,6 @@ interface ListProps {
 
 const List = ({ feedType }: ListProps) => {
   const { currentAccount } = useAccountStore();
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: GroupsRequest = {
     filter: {
@@ -55,11 +49,7 @@ const List = ({ feedType }: ListProps) => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <GroupListShimmer />;
@@ -93,7 +83,7 @@ const List = ({ feedType }: ListProps) => {
             <SingleGroup group={group} showDescription isBig />
           </div>
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </WindowVirtualizer>
     </div>
   );

--- a/apps/web/src/components/Notification/List.tsx
+++ b/apps/web/src/components/Notification/List.tsx
@@ -1,5 +1,6 @@
 import { Card, EmptyState, ErrorMessage } from "@/components/Shared/UI";
 import cn from "@/helpers/cn";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { usePreferencesStore } from "@/store/persisted/usePreferencesStore";
 import { BellIcon } from "@heroicons/react/24/outline";
 import { NotificationFeedType } from "@hey/data/enums";
@@ -8,8 +9,6 @@ import {
   NotificationType,
   useNotificationsQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
-import { useEffect } from "react";
 import { WindowVirtualizer } from "virtua";
 import NotificationShimmer from "./Shimmer";
 import AccountActionExecutedNotification from "./Type/AccountActionExecutedNotification";
@@ -27,11 +26,6 @@ interface ListProps {
 
 const List = ({ feedType }: ListProps) => {
   const { includeLowScore } = usePreferencesStore();
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const getNotificationType = () => {
     switch (feedType) {
@@ -73,11 +67,7 @@ const List = ({ feedType }: ListProps) => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return (
@@ -140,7 +130,7 @@ const List = ({ feedType }: ListProps) => {
             )}
           </div>
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </WindowVirtualizer>
     </Card>
   );

--- a/apps/web/src/components/Post/Quotes.tsx
+++ b/apps/web/src/components/Post/Quotes.tsx
@@ -5,6 +5,7 @@ import {
   EmptyState,
   ErrorMessage
 } from "@/components/Shared/UI";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { ChatBubbleBottomCenterTextIcon } from "@heroicons/react/24/outline";
 import {
   PageSize,
@@ -13,8 +14,6 @@ import {
   type PostReferencesRequest,
   usePostReferencesQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
-import { useEffect } from "react";
 import { WindowVirtualizer } from "virtua";
 import PostsShimmer from "../Shared/Shimmer/PostsShimmer";
 import SinglePost from "./SinglePost";
@@ -24,12 +23,6 @@ interface QuotesProps {
 }
 
 const Quotes = ({ post }: QuotesProps) => {
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
-
   const request: PostReferencesRequest = {
     pageSize: PageSize.Fifty,
     referenceTypes: [PostReferenceType.QuoteOf],
@@ -53,11 +46,7 @@ const Quotes = ({ post }: QuotesProps) => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (error) {
     return <ErrorMessage error={error} title="Failed to load comment feed" />;
@@ -76,7 +65,7 @@ const Quotes = ({ post }: QuotesProps) => {
             {quotes.map((quote) => (
               <SinglePost key={quote.id} post={quote} showType={false} />
             ))}
-            {hasMore && <span ref={ref} />}
+            {hasMore && <span ref={loadMoreRef} />}
           </WindowVirtualizer>
         </div>
       ) : (

--- a/apps/web/src/components/Search/Accounts.tsx
+++ b/apps/web/src/components/Search/Accounts.tsx
@@ -1,6 +1,7 @@
 import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import SingleAccountsShimmer from "@/components/Shared/Shimmer/SingleAccountsShimmer";
 import { Card, EmptyState, ErrorMessage } from "@/components/Shared/UI";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { UsersIcon } from "@heroicons/react/24/outline";
 import {
   AccountsOrderBy,
@@ -8,8 +9,6 @@ import {
   PageSize,
   useAccountsQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
-import { useEffect } from "react";
 import { WindowVirtualizer } from "virtua";
 
 interface AccountsProps {
@@ -17,12 +16,6 @@ interface AccountsProps {
 }
 
 const Accounts = ({ query }: AccountsProps) => {
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
-
   const request: AccountsRequest = {
     pageSize: PageSize.Fifty,
     orderBy: AccountsOrderBy.BestMatch,
@@ -46,11 +39,7 @@ const Accounts = ({ query }: AccountsProps) => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <SingleAccountsShimmer isBig />;
@@ -80,7 +69,7 @@ const Accounts = ({ query }: AccountsProps) => {
           <SingleAccount isBig account={account} showBio />
         </Card>
       ))}
-      {hasMore && <span ref={ref} />}
+      {hasMore && <span ref={loadMoreRef} />}
     </WindowVirtualizer>
   );
 };

--- a/apps/web/src/components/Settings/Blocked/List.tsx
+++ b/apps/web/src/components/Settings/Blocked/List.tsx
@@ -1,6 +1,7 @@
 import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import Loader from "@/components/Shared/Loader";
 import { Button, EmptyState, ErrorMessage } from "@/components/Shared/UI";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { useBlockAlertStore } from "@/store/non-persisted/alert/useBlockAlertStore";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { NoSymbolIcon } from "@heroicons/react/24/outline";
@@ -9,18 +10,11 @@ import {
   PageSize,
   useAccountsBlockedQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
-import { useEffect } from "react";
 import { WindowVirtualizer } from "virtua";
 
 const List = () => {
   const { currentAccount } = useAccountStore();
   const { setShowBlockOrUnblockAlert } = useBlockAlertStore();
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: AccountsBlockedRequest = { pageSize: PageSize.Fifty };
   const { data, error, fetchMore, loading } = useAccountsBlockedQuery({
@@ -40,11 +34,7 @@ const List = () => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <Loader className="my-10" />;
@@ -88,7 +78,7 @@ const List = () => {
             </Button>
           </div>
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </WindowVirtualizer>
     </div>
   );

--- a/apps/web/src/components/Settings/Manager/AccountManager/Management/List.tsx
+++ b/apps/web/src/components/Settings/Manager/AccountManager/Management/List.tsx
@@ -2,6 +2,7 @@ import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import Loader from "@/components/Shared/Loader";
 import { Button, EmptyState, ErrorMessage } from "@/components/Shared/UI";
 import errorToast from "@/helpers/errorToast";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { UsersIcon } from "@heroicons/react/24/outline";
 import {
   type AccountsAvailableRequest,
@@ -11,7 +12,6 @@ import {
   useHideManagedAccountMutation,
   useUnhideManagedAccountMutation
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { WindowVirtualizer } from "virtua";
@@ -24,11 +24,6 @@ interface ListProps {
 const List = ({ managed = false }: ListProps) => {
   const { address } = useAccount();
   const [updatingAccount, setUpdatingAccount] = useState<string | null>(null);
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const lastLoggedInAccountRequest: LastLoggedInAccountRequest = { address };
   const accountsAvailableRequest: AccountsAvailableRequest = {
@@ -73,11 +68,7 @@ const List = ({ managed = false }: ListProps) => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <Loader className="my-10" />;
@@ -160,7 +151,7 @@ const List = ({ managed = false }: ListProps) => {
           )}
         </div>
       ))}
-      {hasMore && <span ref={ref} />}
+      {hasMore && <span ref={loadMoreRef} />}
     </WindowVirtualizer>
   );
 };

--- a/apps/web/src/components/Settings/Manager/AccountManager/Managers/List.tsx
+++ b/apps/web/src/components/Settings/Manager/AccountManager/Managers/List.tsx
@@ -2,6 +2,7 @@ import WalletAccount from "@/components/Shared/Account/WalletAccount";
 import Loader from "@/components/Shared/Loader";
 import { Button, EmptyState, ErrorMessage } from "@/components/Shared/UI";
 import errorToast from "@/helpers/errorToast";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { useApolloClient } from "@apollo/client";
@@ -15,8 +16,7 @@ import {
   useRemoveAccountManagerMutation
 } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { WindowVirtualizer } from "virtua";
 import Permission from "./Permission";
@@ -27,11 +27,6 @@ const List = () => {
     useState<AccountManagerFragment | null>(null);
   const { cache } = useApolloClient();
   const handleTransactionLifecycle = useTransactionLifecycle();
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const updateCache = () => {
     if (removingManager) {
@@ -94,11 +89,7 @@ const List = () => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <Loader className="my-10" />;
@@ -153,7 +144,7 @@ const List = () => {
           </Button>
         </div>
       ))}
-      {hasMore && <span ref={ref} />}
+      {hasMore && <span ref={loadMoreRef} />}
     </WindowVirtualizer>
   );
 };

--- a/apps/web/src/components/Settings/Sessions/List.tsx
+++ b/apps/web/src/components/Settings/Sessions/List.tsx
@@ -2,6 +2,7 @@ import Loader from "@/components/Shared/Loader";
 import { Button, EmptyState, ErrorMessage } from "@/components/Shared/UI";
 import formatDate from "@/helpers/datetime/formatDate";
 import errorToast from "@/helpers/errorToast";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { ComputerDesktopIcon, GlobeAltIcon } from "@heroicons/react/24/outline";
 import {
@@ -11,8 +12,7 @@ import {
   useRevokeAuthenticationMutation
 } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { WindowVirtualizer } from "virtua";
 
@@ -22,11 +22,6 @@ const List = () => {
   const [revokeingSessionId, setRevokeingSessionId] = useState<null | string>(
     null
   );
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const onError = (error: ApolloClientError) => {
     setRevoking(false);
@@ -75,11 +70,7 @@ const List = () => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <Loader className="my-10" />;
@@ -154,7 +145,7 @@ const List = () => {
             </Button>
           </div>
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </WindowVirtualizer>
     </div>
   );

--- a/apps/web/src/components/Shared/Modal/Followers.tsx
+++ b/apps/web/src/components/Shared/Modal/Followers.tsx
@@ -2,14 +2,13 @@ import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
 import { EmptyState, ErrorMessage } from "@/components/Shared/UI";
 import cn from "@/helpers/cn";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { accountsList } from "@/variants";
 import { UsersIcon } from "@heroicons/react/24/outline";
 import type { FollowersRequest } from "@hey/indexer";
 import { PageSize, useFollowersQuery } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
 import { motion } from "motion/react";
-import { useEffect } from "react";
 import { Virtualizer } from "virtua";
 
 interface FollowersProps {
@@ -19,11 +18,6 @@ interface FollowersProps {
 
 const Followers = ({ username, address }: FollowersProps) => {
   const { currentAccount } = useAccountStore();
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: FollowersRequest = {
     pageSize: PageSize.Fifty,
@@ -47,11 +41,7 @@ const Followers = ({ username, address }: FollowersProps) => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <AccountListShimmer />;
@@ -109,7 +99,7 @@ const Followers = ({ username, address }: FollowersProps) => {
             />
           </motion.div>
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </Virtualizer>
     </div>
   );

--- a/apps/web/src/components/Shared/Modal/FollowersYouKnow.tsx
+++ b/apps/web/src/components/Shared/Modal/FollowersYouKnow.tsx
@@ -2,6 +2,7 @@ import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
 import { EmptyState, ErrorMessage } from "@/components/Shared/UI";
 import cn from "@/helpers/cn";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { accountsList } from "@/variants";
 import { UsersIcon } from "@heroicons/react/24/outline";
@@ -9,9 +10,7 @@ import {
   type FollowersYouKnowRequest,
   useFollowersYouKnowQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
 import { motion } from "motion/react";
-import { useEffect } from "react";
 import { Virtualizer } from "virtua";
 
 interface FollowersYouKnowProps {
@@ -21,11 +20,6 @@ interface FollowersYouKnowProps {
 
 const FollowersYouKnow = ({ username, address }: FollowersYouKnowProps) => {
   const { currentAccount } = useAccountStore();
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: FollowersYouKnowRequest = {
     observer: currentAccount?.address,
@@ -49,11 +43,7 @@ const FollowersYouKnow = ({ username, address }: FollowersYouKnowProps) => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <AccountListShimmer />;
@@ -111,7 +101,7 @@ const FollowersYouKnow = ({ username, address }: FollowersYouKnowProps) => {
             />
           </motion.div>
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </Virtualizer>
     </div>
   );

--- a/apps/web/src/components/Shared/Modal/Following.tsx
+++ b/apps/web/src/components/Shared/Modal/Following.tsx
@@ -2,14 +2,13 @@ import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
 import { EmptyState, ErrorMessage } from "@/components/Shared/UI";
 import cn from "@/helpers/cn";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { accountsList } from "@/variants";
 import { UsersIcon } from "@heroicons/react/24/outline";
 import type { FollowingRequest } from "@hey/indexer";
 import { PageSize, useFollowingQuery } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
 import { motion } from "motion/react";
-import { useEffect } from "react";
 import { Virtualizer } from "virtua";
 
 interface FollowingProps {
@@ -19,11 +18,6 @@ interface FollowingProps {
 
 const Following = ({ username, address }: FollowingProps) => {
   const { currentAccount } = useAccountStore();
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: FollowingRequest = {
     pageSize: PageSize.Fifty,
@@ -47,11 +41,7 @@ const Following = ({ username, address }: FollowingProps) => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <AccountListShimmer />;
@@ -109,7 +99,7 @@ const Following = ({ username, address }: FollowingProps) => {
             />
           </motion.div>
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </Virtualizer>
     </div>
   );

--- a/apps/web/src/components/Shared/Modal/Likes.tsx
+++ b/apps/web/src/components/Shared/Modal/Likes.tsx
@@ -2,6 +2,7 @@ import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
 import { EmptyState, ErrorMessage } from "@/components/Shared/UI";
 import cn from "@/helpers/cn";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { accountsList } from "@/variants";
 import { HeartIcon } from "@heroicons/react/24/outline";
@@ -10,9 +11,7 @@ import {
   type PostReactionsRequest,
   usePostReactionsQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
 import { motion } from "motion/react";
-import { useEffect } from "react";
 import { Virtualizer } from "virtua";
 
 interface LikesProps {
@@ -21,11 +20,6 @@ interface LikesProps {
 
 const Likes = ({ postId }: LikesProps) => {
   const { currentAccount } = useAccountStore();
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: PostReactionsRequest = {
     post: postId,
@@ -49,11 +43,7 @@ const Likes = ({ postId }: LikesProps) => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <AccountListShimmer />;
@@ -108,7 +98,7 @@ const Likes = ({ postId }: LikesProps) => {
             />
           </motion.div>
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </Virtualizer>
     </div>
   );

--- a/apps/web/src/components/Shared/Modal/Members/index.tsx
+++ b/apps/web/src/components/Shared/Modal/Members/index.tsx
@@ -2,6 +2,7 @@ import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
 import { EmptyState, ErrorMessage } from "@/components/Shared/UI";
 import cn from "@/helpers/cn";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { accountsList } from "@/variants";
 import { UsersIcon } from "@heroicons/react/24/outline";
@@ -11,9 +12,7 @@ import {
   PageSize,
   useGroupMembersQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
 import { motion } from "motion/react";
-import { useEffect } from "react";
 import { Virtualizer } from "virtua";
 
 interface MembersProps {
@@ -22,11 +21,6 @@ interface MembersProps {
 
 const Members = ({ group }: MembersProps) => {
   const { currentAccount } = useAccountStore();
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: GroupMembersRequest = {
     pageSize: PageSize.Fifty,
@@ -50,11 +44,7 @@ const Members = ({ group }: MembersProps) => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <AccountListShimmer />;
@@ -107,7 +97,7 @@ const Members = ({ group }: MembersProps) => {
             />
           </motion.div>
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </Virtualizer>
     </div>
   );

--- a/apps/web/src/components/Shared/Modal/PostExecutors.tsx
+++ b/apps/web/src/components/Shared/Modal/PostExecutors.tsx
@@ -2,6 +2,7 @@ import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
 import { EmptyState, ErrorMessage } from "@/components/Shared/UI";
 import cn from "@/helpers/cn";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { accountsList } from "@/variants";
 import { ShoppingBagIcon } from "@heroicons/react/24/outline";
@@ -10,9 +11,7 @@ import {
   type WhoExecutedActionOnPostRequest,
   useWhoExecutedActionOnPostQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
 import { motion } from "motion/react";
-import { useEffect } from "react";
 import { Virtualizer } from "virtua";
 
 interface PostExecutorsProps {
@@ -22,11 +21,6 @@ interface PostExecutorsProps {
 
 const PostExecutors = ({ postId, filter }: PostExecutorsProps) => {
   const { currentAccount } = useAccountStore();
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: WhoExecutedActionOnPostRequest = {
     post: postId,
@@ -50,11 +44,7 @@ const PostExecutors = ({ postId, filter }: PostExecutorsProps) => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <AccountListShimmer />;
@@ -109,7 +99,7 @@ const PostExecutors = ({ postId, filter }: PostExecutorsProps) => {
             />
           </motion.div>
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </Virtualizer>
     </div>
   );

--- a/apps/web/src/components/Shared/Modal/Reposts.tsx
+++ b/apps/web/src/components/Shared/Modal/Reposts.tsx
@@ -2,6 +2,7 @@ import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
 import { EmptyState, ErrorMessage } from "@/components/Shared/UI";
 import cn from "@/helpers/cn";
+import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { accountsList } from "@/variants";
 import { ArrowsRightLeftIcon } from "@heroicons/react/24/outline";
@@ -11,9 +12,7 @@ import {
   type WhoReferencedPostRequest,
   useWhoReferencedPostQuery
 } from "@hey/indexer";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
 import { motion } from "motion/react";
-import { useEffect } from "react";
 import { Virtualizer } from "virtua";
 
 interface RepostsProps {
@@ -22,11 +21,6 @@ interface RepostsProps {
 
 const Reposts = ({ postId }: RepostsProps) => {
   const { currentAccount } = useAccountStore();
-  const [ref, entry] = useIntersectionObserver({
-    threshold: 0,
-    root: null,
-    rootMargin: "0px"
-  });
 
   const request: WhoReferencedPostRequest = {
     pageSize: PageSize.Fifty,
@@ -51,11 +45,7 @@ const Reposts = ({ postId }: RepostsProps) => {
     }
   };
 
-  useEffect(() => {
-    if (entry?.isIntersecting) {
-      onEndReached();
-    }
-  }, [entry?.isIntersecting]);
+  const loadMoreRef = useLoadMoreOnIntersect(onEndReached);
 
   if (loading) {
     return <AccountListShimmer />;
@@ -106,7 +96,7 @@ const Reposts = ({ postId }: RepostsProps) => {
             />
           </motion.div>
         ))}
-        {hasMore && <span ref={ref} />}
+        {hasMore && <span ref={loadMoreRef} />}
       </Virtualizer>
     </div>
   );


### PR DESCRIPTION
## Summary
- centralize intersection logic with `useLoadMoreOnIntersect`
- simplify notification and settings lists to call the new hook
- update search, groups, post quotes and modal lists

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d0499980083308e6c8fa9594ae218