### PR TITLE
Update README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Navigate to the root of the repository and install all dependencies using pnpm:
 pnpm install
 ```
 
-### Setup Environment Variables
+### Set Up Environment Variables
 
 Copy the `.env.example` file to create a new `.env` file for each package or app that requires environment configuration:
 


### PR DESCRIPTION
## Summary
- fix the heading for environment variables in README

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck` *(fails: Cannot find name 'blockingorUnblockingAccount')*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d7ad11e4c8330be2f7b0f0f0436c0