### PR TITLE
Fix terms warranty text

### DIFF
--- a/apps/web/src/components/Pages/Terms.tsx
+++ b/apps/web/src/components/Pages/Terms.tsx
@@ -274,8 +274,8 @@ const Terms = () => {
               {/* 11. Disclaimer of Warranties begins */}
               <H4 className="mt-8 mb-5">11. Disclaimer of Warranties</H4>
               <p className="leading-7">
-                The Site are provided to you completely as they are, and could
-                function differently than you expected. You agree to accept the
+                The Site is provided to you completely as it is, and could
+                function differently than you expect. You agree to accept the
                 Site as is. You expressly agree that your use of, or inability
                 to use, the Site is at your sole risk. Our liability shall be
                 limited entirely or to the maximum extent permitted by law.

--- a/apps/web/src/components/Shared/Alert/BlockOrUnblockAccount.tsx
+++ b/apps/web/src/components/Shared/Alert/BlockOrUnblockAccount.tsx
@@ -112,7 +112,7 @@ const BlockOrUnblockAccount = () => {
       confirmText={hasBlocked ? "Unblock" : "Block"}
       description={`Are you sure you want to ${
         hasBlocked ? "unblock" : "block"
-      } ${getAccount(blockingorUnblockingAccount).usernameWithPrefix}?`}
+      } ${getAccount(blockingOrUnblockingAccount).usernameWithPrefix}?`}
       isPerformingAction={isSubmitting}
       onClose={() => setShowBlockOrUnblockAlert(false)}
       onConfirm={blockOrUnblock}


### PR DESCRIPTION
## Summary
- fix grammar in the disclaimer of warranties section
- fix variable typo in `BlockOrUnblockAccount`

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d7ad5b9bc83308277b45428a82a04