### PR TITLE
Fix terms wording

### DIFF
--- a/apps/web/src/components/Pages/Terms.tsx
+++ b/apps/web/src/components/Pages/Terms.tsx
@@ -88,7 +88,7 @@ const Terms = () => {
                 </p>
                 <ul className="list-inside list-disc space-y-3">
                   <li className="leading-7">
-                    Your account your responsibility.
+                    Your account is your responsibility.
                   </li>
                   <li className="leading-7">
                     You are responsible for securing the wallet that contains

--- a/apps/web/src/components/Shared/Alert/BlockOrUnblockAccount.tsx
+++ b/apps/web/src/components/Shared/Alert/BlockOrUnblockAccount.tsx
@@ -112,7 +112,7 @@ const BlockOrUnblockAccount = () => {
       confirmText={hasBlocked ? "Unblock" : "Block"}
       description={`Are you sure you want to ${
         hasBlocked ? "unblock" : "block"
-      } ${getAccount(blockingorUnblockingAccount).usernameWithPrefix}?`}
+      } ${getAccount(blockingOrUnblockingAccount).usernameWithPrefix}?`}
       isPerformingAction={isSubmitting}
       onClose={() => setShowBlockOrUnblockAlert(false)}
       onConfirm={blockOrUnblock}


### PR DESCRIPTION
## Summary
- correct wording in Terms page bullet list
- fix a typo causing typecheck failure

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d7ad7c604833098a8b4fa7d6c3123