### PR TITLE
Fix signup username store field

### DIFF
--- a/apps/web/src/components/Shared/Alert/BlockOrUnblockAccount.tsx
+++ b/apps/web/src/components/Shared/Alert/BlockOrUnblockAccount.tsx
@@ -112,7 +112,7 @@ const BlockOrUnblockAccount = () => {
       confirmText={hasBlocked ? "Unblock" : "Block"}
       description={`Are you sure you want to ${
         hasBlocked ? "unblock" : "block"
-      } ${getAccount(blockingorUnblockingAccount).usernameWithPrefix}?`}
+      } ${getAccount(blockingOrUnblockingAccount).usernameWithPrefix}?`}
       isPerformingAction={isSubmitting}
       onClose={() => setShowBlockOrUnblockAlert(false)}
       onConfirm={blockOrUnblock}

--- a/apps/web/src/components/Shared/Auth/Signup/ChooseUsername.tsx
+++ b/apps/web/src/components/Shared/Auth/Signup/ChooseUsername.tsx
@@ -45,7 +45,7 @@ const ValidationSchema = z.object({
 
 const ChooseUsername = () => {
   const {
-    setChoosedUsername,
+    setChosenUsername,
     setScreen,
     setTransactionHash,
     setOnboardingToken
@@ -133,7 +133,7 @@ const ChooseUsername = () => {
               createAccountWithUsername.__typename === "CreateAccountResponse"
             ) {
               setTransactionHash(createAccountWithUsername.hash);
-              setChoosedUsername(username);
+              setChosenUsername(username);
               setScreen("minting");
             }
           }

--- a/apps/web/src/components/Shared/Auth/Signup/Minting.tsx
+++ b/apps/web/src/components/Shared/Auth/Signup/Minting.tsx
@@ -3,7 +3,7 @@ import { useAccountQuery } from "@hey/indexer";
 import { useSignupStore } from ".";
 
 const Minting = () => {
-  const { choosedUsername, setAccountAddress, setScreen, transactionHash } =
+  const { chosenUsername, setAccountAddress, setScreen, transactionHash } =
     useSignupStore();
 
   useAccountQuery({
@@ -16,7 +16,7 @@ const Minting = () => {
     },
     pollInterval: 1500,
     skip: !transactionHash,
-    variables: { request: { username: { localName: choosedUsername } } }
+    variables: { request: { username: { localName: chosenUsername } } }
   });
 
   return (

--- a/apps/web/src/components/Shared/Auth/Signup/index.tsx
+++ b/apps/web/src/components/Shared/Auth/Signup/index.tsx
@@ -7,12 +7,12 @@ import Minting from "./Minting";
 import Success from "./Success";
 
 interface SignupState {
-  choosedUsername: string;
+  chosenUsername: string;
   accountAddress: string;
   screen: "choose" | "minting" | "success";
   transactionHash: string;
   onboardingToken: string;
-  setChoosedUsername: (username: string) => void;
+  setChosenUsername: (username: string) => void;
   setAccountAddress: (accountAddress: string) => void;
   setScreen: (screen: "choose" | "minting" | "success") => void;
   setTransactionHash: (hash: string) => void;
@@ -20,12 +20,12 @@ interface SignupState {
 }
 
 const store = create<SignupState>((set) => ({
-  choosedUsername: "",
+  chosenUsername: "",
   accountAddress: "",
   screen: "choose",
   transactionHash: "",
   onboardingToken: "",
-  setChoosedUsername: (username) => set({ choosedUsername: username }),
+  setChosenUsername: (username) => set({ chosenUsername: username }),
   setAccountAddress: (accountAddress) => set({ accountAddress }),
   setScreen: (screen) => set({ screen }),
   setTransactionHash: (hash) => set({ transactionHash: hash }),


### PR DESCRIPTION
## Summary
- rename `choosedUsername` state to `chosenUsername`
- update Signup state and all usages
- fix typo in `BlockOrUnblockAccount`

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d7ad9fb7c8330a06397e653f5c2f3