### PR TITLE
Refactor upload metadata typing

### DIFF
--- a/apps/web/src/helpers/uploadMetadata.ts
+++ b/apps/web/src/helpers/uploadMetadata.ts
@@ -3,7 +3,13 @@ import { Errors } from "@hey/data/errors";
 import { immutable } from "@lens-chain/storage-client";
 import { storageClient } from "./storageClient";
 
-const uploadMetadata = async (data: any): Promise<string> => {
+interface MetadataPayload {
+  [key: string]: unknown;
+}
+
+const uploadMetadata = async (
+  data: MetadataPayload | null
+): Promise<string> => {
   try {
     const { uri } = await storageClient.uploadAsJson(data, {
       acl: immutable(CHAIN.id)


### PR DESCRIPTION
## Summary
- define `MetadataPayload` interface
- update `uploadMetadata` to accept typed payload and return a `Promise<string>`

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684d9f0cf8ec8330bcde8976a89b27d0