### PR TITLE
Add AttachmentData interface and update helpers

### DIFF
--- a/packages/helpers/getAttachmentsData.ts
+++ b/packages/helpers/getAttachmentsData.ts
@@ -1,7 +1,10 @@
 import type { AnyMediaFragment, Maybe } from "@hey/indexer";
+import type { AttachmentData } from "@hey/types/misc";
 import sanitizeDStorageUrl from "./sanitizeDStorageUrl";
 
-const getAttachmentsData = (attachments?: Maybe<AnyMediaFragment[]>): any => {
+const getAttachmentsData = (
+  attachments?: Maybe<AnyMediaFragment[]>
+): AttachmentData[] => {
   if (!attachments) {
     return [];
   }
@@ -12,22 +15,22 @@ const getAttachmentsData = (attachments?: Maybe<AnyMediaFragment[]>): any => {
         return {
           type: "Image",
           uri: sanitizeDStorageUrl(attachment.item)
-        };
+        } satisfies AttachmentData;
       case "MediaVideo":
         return {
           coverUri: sanitizeDStorageUrl(attachment.cover),
           type: "Video",
           uri: sanitizeDStorageUrl(attachment.item)
-        };
+        } satisfies AttachmentData;
       case "MediaAudio":
         return {
           artist: attachment.artist,
           coverUri: sanitizeDStorageUrl(attachment.cover),
           type: "Audio",
           uri: sanitizeDStorageUrl(attachment.item)
-        };
+        } satisfies AttachmentData;
       default:
-        return [];
+        return {} as AttachmentData;
     }
   });
 };

--- a/packages/helpers/getPostData.ts
+++ b/packages/helpers/getPostData.ts
@@ -1,6 +1,6 @@
 import { PLACEHOLDER_IMAGE } from "@hey/data/constants";
 import type { PostMetadataFragment } from "@hey/indexer";
-import type { MetadataAsset } from "@hey/types/misc";
+import type { AttachmentData, MetadataAsset } from "@hey/types/misc";
 import getAttachmentsData from "./getAttachmentsData";
 import sanitizeDStorageUrl from "./sanitizeDStorageUrl";
 
@@ -8,10 +8,7 @@ const getPostData = (
   metadata: PostMetadataFragment
 ): {
   asset?: MetadataAsset;
-  attachments?: {
-    type: "Audio" | "Image" | "Video";
-    uri: string;
-  }[];
+  attachments?: AttachmentData[];
   content?: string;
 } | null => {
   switch (metadata.__typename) {
@@ -46,7 +43,8 @@ const getPostData = (
 
       return {
         asset: {
-          artist: metadata.audio.artist || audioAttachments?.artist,
+          artist:
+            metadata.audio.artist ?? audioAttachments?.artist ?? undefined,
           cover: sanitizeDStorageUrl(
             metadata.audio.cover ||
               audioAttachments?.coverUri ||

--- a/packages/types/misc.d.ts
+++ b/packages/types/misc.d.ts
@@ -34,3 +34,10 @@ export interface MetadataAsset {
   type: "Audio" | "Image" | "Video";
   uri: string;
 }
+
+export interface AttachmentData {
+  artist?: string | null;
+  coverUri?: string;
+  type: "Audio" | "Image" | "Video";
+  uri: string;
+}


### PR DESCRIPTION
## Summary
- add a new `AttachmentData` interface
- return `AttachmentData[]` from `getAttachmentsData`
- consume the new type in `getPostData`

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d9f1dd75083309e2bb366c45782be