### PR TITLE
Refactor lens endpoint exports

### DIFF
--- a/packages/data/constants.ts
+++ b/packages/data/constants.ts
@@ -1,5 +1,5 @@
 import { chains } from "@lens-chain/sdk/viem";
-import LensEndpoint from "./lens-endpoints";
+import { LENS_ENDPOINT } from "./lens-endpoints";
 import getEnvConfig from "./utils/getEnvConfig";
 
 // Environments
@@ -17,7 +17,7 @@ export const HEY_API_URL = IS_PRODUCTION
   ? HEY_API_PRODUCTION_URL
   : "http://localhost:4784";
 
-export const IS_MAINNET = LENS_API_URL === LensEndpoint.Mainnet;
+export const IS_MAINNET = LENS_API_URL === LENS_ENDPOINT.Mainnet;
 export const CHAIN = IS_MAINNET ? chains.mainnet : chains.testnet;
 export const ADDRESS_PLACEHOLDER = "0x03Ba3...7EF";
 export const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";

--- a/packages/data/lens-endpoints.ts
+++ b/packages/data/lens-endpoints.ts
@@ -1,7 +1,7 @@
-enum LensEndpoint {
-  Mainnet = "https://api.lens.xyz/graphql",
-  Testnet = "https://api.testnet.lens.xyz/graphql",
-  Staging = "https://api.staging.lens.xyz/graphql"
-}
+export const LENS_ENDPOINT = {
+  Mainnet: "https://api.lens.xyz/graphql",
+  Testnet: "https://api.testnet.lens.xyz/graphql",
+  Staging: "https://api.staging.lens.xyz/graphql"
+} as const;
 
-export default LensEndpoint;
+export type LensEndpoint = (typeof LENS_ENDPOINT)[keyof typeof LENS_ENDPOINT];

--- a/packages/data/utils/getEnvConfig.ts
+++ b/packages/data/utils/getEnvConfig.ts
@@ -1,6 +1,6 @@
 import { LENS_NETWORK } from "../constants";
 import { MainnetContracts, TestnetContracts } from "../contracts";
-import LensEndpoint from "../lens-endpoints";
+import { LENS_ENDPOINT } from "../lens-endpoints";
 
 const getEnvConfig = (): {
   lensApiEndpoint: string;
@@ -15,17 +15,17 @@ const getEnvConfig = (): {
   switch (LENS_NETWORK) {
     case "testnet":
       return {
-        lensApiEndpoint: LensEndpoint.Testnet,
+        lensApiEndpoint: LENS_ENDPOINT.Testnet,
         ...testnetContracts
       };
     case "staging":
       return {
-        lensApiEndpoint: LensEndpoint.Staging,
+        lensApiEndpoint: LENS_ENDPOINT.Staging,
         ...testnetContracts
       };
     default:
       return {
-        lensApiEndpoint: LensEndpoint.Mainnet,
+        lensApiEndpoint: LENS_ENDPOINT.Mainnet,
         defaultCollectToken: MainnetContracts.DefaultToken,
         appAddress: MainnetContracts.App
       };

--- a/packages/indexer/codegen.ts
+++ b/packages/indexer/codegen.ts
@@ -1,5 +1,5 @@
 import type { CodegenConfig } from "@graphql-codegen/cli";
-import LensEndpoint from "@hey/data/lens-endpoints";
+import { LENS_ENDPOINT } from "@hey/data/lens-endpoints";
 
 const config: CodegenConfig = {
   config: {
@@ -29,7 +29,7 @@ const config: CodegenConfig = {
   },
   hooks: { afterAllFileWrite: ["biome format --write ."] },
   overwrite: true,
-  schema: LensEndpoint.Mainnet
+  schema: LENS_ENDPOINT.Mainnet
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- refactor `packages/data/lens-endpoints.ts` to export a readonly object and a union type
- update all references to use the new `LENS_ENDPOINT` constant

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d9f810dac83308de86b58f7ef7ab6