### PR TITLE
Switch Errors enum to object

### DIFF
--- a/apps/api/src/routes/cron/guild/syncFollowersStandingToGuild.ts
+++ b/apps/api/src/routes/cron/guild/syncFollowersStandingToGuild.ts
@@ -1,4 +1,4 @@
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 import lensPg from "src/utils/lensPg";
 import syncAddressesToGuild from "src/utils/syncAddressesToGuild";
@@ -26,7 +26,7 @@ const syncFollowersStandingToGuild = async (ctx: Context) => {
 
     return ctx.json(data);
   } catch {
-    return ctx.json({ success: false, error: Errors.SomethingWentWrong }, 500);
+    return ctx.json({ success: false, error: ERRORS.SomethingWentWrong }, 500);
   }
 };
 

--- a/apps/api/src/routes/cron/guild/syncSubscribersToGuild.ts
+++ b/apps/api/src/routes/cron/guild/syncSubscribersToGuild.ts
@@ -1,5 +1,5 @@
 import { PERMISSIONS } from "@hey/data/constants";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 import lensPg from "src/utils/lensPg";
 import syncAddressesToGuild from "src/utils/syncAddressesToGuild";
@@ -32,7 +32,7 @@ const syncSubscribersToGuild = async (ctx: Context) => {
 
     return ctx.json(data);
   } catch {
-    return ctx.json({ success: false, error: Errors.SomethingWentWrong }, 500);
+    return ctx.json({ success: false, error: ERRORS.SomethingWentWrong }, 500);
   }
 };
 

--- a/apps/api/src/routes/cron/removeExpiredSubscribers/index.ts
+++ b/apps/api/src/routes/cron/removeExpiredSubscribers/index.ts
@@ -1,5 +1,5 @@
 import { PERMISSIONS } from "@hey/data/constants";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 import lensPg from "src/utils/lensPg";
 import signer from "src/utils/signer";
@@ -41,7 +41,7 @@ const removeExpiredSubscribers = async (ctx: Context) => {
 
     return ctx.json({ success: true, addresses, hash });
   } catch {
-    return ctx.json({ success: false, error: Errors.SomethingWentWrong }, 500);
+    return ctx.json({ success: false, error: ERRORS.SomethingWentWrong }, 500);
   }
 };
 

--- a/apps/api/src/routes/jumper/getStats.ts
+++ b/apps/api/src/routes/jumper/getStats.ts
@@ -1,4 +1,4 @@
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 import getDbPostId from "src/utils/getDbPostId";
 import lensPg from "src/utils/lensPg";
@@ -60,7 +60,7 @@ const getStats = async (ctx: Context) => {
       comments: Number(result[2].count)
     });
   } catch {
-    return ctx.json({ success: false, error: Errors.SomethingWentWrong }, 500);
+    return ctx.json({ success: false, error: ERRORS.SomethingWentWrong }, 500);
   }
 };
 

--- a/apps/api/src/routes/lens/authorization.ts
+++ b/apps/api/src/routes/lens/authorization.ts
@@ -1,4 +1,4 @@
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 
 const authorization = async (ctx: Context) => {
@@ -21,7 +21,7 @@ const authorization = async (ctx: Context) => {
       signingKey: process.env.PRIVATE_KEY
     });
   } catch {
-    return ctx.json({ success: false, error: Errors.SomethingWentWrong }, 500);
+    return ctx.json({ success: false, error: ERRORS.SomethingWentWrong }, 500);
   }
 };
 

--- a/apps/api/src/routes/live/createLive.ts
+++ b/apps/api/src/routes/live/createLive.ts
@@ -1,5 +1,5 @@
 import { LIVEPEER_KEY } from "@hey/data/constants";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import generateUUID from "@hey/helpers/generateUUID";
 import type { Context } from "hono";
 
@@ -45,7 +45,7 @@ const createLive = async (ctx: Context) => {
       }
     });
   } catch {
-    return ctx.json({ success: false, error: Errors.SomethingWentWrong }, 500);
+    return ctx.json({ success: false, error: ERRORS.SomethingWentWrong }, 500);
   }
 };
 

--- a/apps/api/src/routes/metadata/getSTS.ts
+++ b/apps/api/src/routes/metadata/getSTS.ts
@@ -1,6 +1,6 @@
 import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
 import { EVER_API, EVER_BUCKET, EVER_REGION } from "@hey/data/constants";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 
 const params = {
@@ -49,7 +49,7 @@ const getSTS = async (ctx: Context) => {
       }
     });
   } catch {
-    return ctx.json({ success: false, error: Errors.SomethingWentWrong }, 500);
+    return ctx.json({ success: false, error: ERRORS.SomethingWentWrong }, 500);
   }
 };
 

--- a/apps/api/src/routes/oembed/getOembed.ts
+++ b/apps/api/src/routes/oembed/getOembed.ts
@@ -1,4 +1,4 @@
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 import { CACHE_AGE_1_DAY } from "src/utils/constants";
 import { generateExtraLongExpiry, getRedis, setRedis } from "src/utils/redis";
@@ -26,7 +26,7 @@ const getOembed = async (ctx: Context) => {
 
     return ctx.json({ success: true, data: oembed });
   } catch {
-    return ctx.json({ success: false, error: Errors.SomethingWentWrong }, 500);
+    return ctx.json({ success: false, error: ERRORS.SomethingWentWrong }, 500);
   }
 };
 

--- a/apps/api/src/routes/preferences/getPreferences.ts
+++ b/apps/api/src/routes/preferences/getPreferences.ts
@@ -1,4 +1,4 @@
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 import prisma from "src/prisma/client";
 import { getRedis, setRedis } from "src/utils/redis";
@@ -31,7 +31,7 @@ const getPreferences = async (ctx: Context) => {
 
     return ctx.json({ success: true, data });
   } catch {
-    return ctx.json({ success: false, error: Errors.SomethingWentWrong }, 500);
+    return ctx.json({ success: false, error: ERRORS.SomethingWentWrong }, 500);
   }
 };
 

--- a/apps/api/src/routes/preferences/updatePreferences.ts
+++ b/apps/api/src/routes/preferences/updatePreferences.ts
@@ -1,4 +1,4 @@
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 import prisma from "src/prisma/client";
 import { delRedis } from "src/utils/redis";
@@ -24,7 +24,7 @@ const updatePreferences = async (ctx: Context) => {
       }
     });
   } catch {
-    return ctx.json({ success: false, error: Errors.SomethingWentWrong }, 500);
+    return ctx.json({ success: false, error: ERRORS.SomethingWentWrong }, 500);
   }
 };
 

--- a/apps/api/src/routes/sitemap/accounts/accountSitemap.ts
+++ b/apps/api/src/routes/sitemap/accounts/accountSitemap.ts
@@ -1,4 +1,4 @@
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 import { SITEMAP_BATCH_SIZE } from "src/utils/constants";
 import lensPg from "src/utils/lensPg";
@@ -11,11 +11,11 @@ const accountSitemap = async (ctx: Context) => {
   const batch = params["batch.xml"].replace(".xml", "");
 
   if (Number.isNaN(Number(group)) || Number.isNaN(Number(batch))) {
-    return ctx.body(Errors.SomethingWentWrong);
+    return ctx.body(ERRORS.SomethingWentWrong);
   }
 
   if (Number(group) === 0 || Number(batch) === 0) {
-    return ctx.body(Errors.SomethingWentWrong);
+    return ctx.body(ERRORS.SomethingWentWrong);
   }
 
   try {
@@ -71,7 +71,7 @@ const accountSitemap = async (ctx: Context) => {
     ctx.header("Content-Type", "application/xml");
     return ctx.body(sitemap.end({ prettyPrint: true }));
   } catch {
-    return ctx.body(Errors.SomethingWentWrong);
+    return ctx.body(ERRORS.SomethingWentWrong);
   }
 };
 

--- a/apps/api/src/routes/sitemap/accounts/accountsGroupSitemap.ts
+++ b/apps/api/src/routes/sitemap/accounts/accountsGroupSitemap.ts
@@ -1,4 +1,4 @@
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 import { SITEMAP_BATCH_SIZE } from "src/utils/constants";
 import lensPg from "src/utils/lensPg";
@@ -10,7 +10,7 @@ const accountsGroupSitemap = async (ctx: Context) => {
   const groupParam = params["group.xml"].replace(".xml", "");
 
   if (Number.isNaN(Number(groupParam)) || Number(groupParam) === 0) {
-    return ctx.body(Errors.SomethingWentWrong);
+    return ctx.body(ERRORS.SomethingWentWrong);
   }
 
   const group = Number(groupParam);
@@ -59,7 +59,7 @@ const accountsGroupSitemap = async (ctx: Context) => {
     ctx.header("Content-Type", "application/xml");
     return ctx.body(sitemapIndex.end({ prettyPrint: true }));
   } catch {
-    return ctx.body(Errors.SomethingWentWrong);
+    return ctx.body(ERRORS.SomethingWentWrong);
   }
 };
 

--- a/apps/api/src/routes/sitemap/accounts/accountsSitemapIndex.ts
+++ b/apps/api/src/routes/sitemap/accounts/accountsSitemapIndex.ts
@@ -1,4 +1,4 @@
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 import { SITEMAP_BATCH_SIZE } from "src/utils/constants";
 import lensPg from "src/utils/lensPg";
@@ -47,7 +47,7 @@ const accountsSitemapIndex = async (ctx: Context) => {
     ctx.header("Content-Type", "application/xml");
     return ctx.body(sitemapIndex.end({ prettyPrint: true }));
   } catch {
-    return ctx.body(Errors.SomethingWentWrong);
+    return ctx.body(ERRORS.SomethingWentWrong);
   }
 };
 

--- a/apps/api/src/routes/sitemap/pagesSitemap.ts
+++ b/apps/api/src/routes/sitemap/pagesSitemap.ts
@@ -1,4 +1,4 @@
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 import { create } from "xmlbuilder2";
 
@@ -31,7 +31,7 @@ const pagesSitemap = async (ctx: Context) => {
     ctx.header("Content-Type", "application/xml");
     return ctx.body(sitemap.end({ prettyPrint: true }));
   } catch {
-    return ctx.body(Errors.SomethingWentWrong);
+    return ctx.body(ERRORS.SomethingWentWrong);
   }
 };
 

--- a/apps/api/src/routes/sitemap/sitemapIndex.ts
+++ b/apps/api/src/routes/sitemap/sitemapIndex.ts
@@ -1,4 +1,4 @@
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 import { create } from "xmlbuilder2";
 
@@ -28,7 +28,7 @@ const sitemapIndex = async (ctx: Context) => {
     ctx.header("Content-Type", "application/xml");
     return ctx.body(sitemapIndex.end({ prettyPrint: true }));
   } catch {
-    return ctx.body(Errors.SomethingWentWrong);
+    return ctx.body(ERRORS.SomethingWentWrong);
   }
 };
 

--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -28,7 +28,7 @@ import {
   usePostVideoStore
 } from "@/store/non-persisted/post/usePostVideoStore";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import getAccount from "@hey/helpers/getAccount";
 import type { PostFragment } from "@hey/indexer";
 import type { IGif } from "@hey/types/giphy";
@@ -169,7 +169,7 @@ const NewPublication = ({ className, post, feed }: NewPublicationProps) => {
 
   const handleCreatePost = async () => {
     if (!currentAccount) {
-      return toast.error(Errors.SignWallet);
+      return toast.error(ERRORS.SignWallet);
     }
 
     try {

--- a/apps/web/src/components/Group/Settings/Personalize/Form.tsx
+++ b/apps/web/src/components/Group/Settings/Personalize/Form.tsx
@@ -14,7 +14,7 @@ import errorToast from "@/helpers/errorToast";
 import uploadMetadata from "@/helpers/uploadMetadata";
 import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import { Regex } from "@hey/data/regex";
 import { type GroupFragment, useSetGroupMetadataMutation } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
@@ -89,7 +89,7 @@ const PersonalizeSettingsForm = ({ group }: PersonalizeSettingsFormProps) => {
     coverUrl: string | undefined
   ) => {
     if (!currentAccount) {
-      return toast.error(Errors.SignWallet);
+      return toast.error(ERRORS.SignWallet);
     }
 
     setIsSubmitting(true);

--- a/apps/web/src/components/Post/Actions/Like.tsx
+++ b/apps/web/src/components/Post/Actions/Like.tsx
@@ -5,7 +5,7 @@ import { useAccountStore } from "@/store/persisted/useAccountStore";
 import type { ApolloCache } from "@apollo/client";
 import { HeartIcon } from "@heroicons/react/24/outline";
 import { HeartIcon as HeartIconSolid } from "@heroicons/react/24/solid";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import {
   type PostFragment,
   PostReactionType,
@@ -75,7 +75,7 @@ const Like = ({ post, showCount }: LikeProps) => {
 
   const handleCreateLike = async () => {
     if (!currentAccount) {
-      return toast.error(Errors.SignWallet);
+      return toast.error(ERRORS.SignWallet);
     }
 
     toggleReact();

--- a/apps/web/src/components/Post/Actions/Share/Quote.tsx
+++ b/apps/web/src/components/Post/Actions/Share/Quote.tsx
@@ -4,7 +4,7 @@ import { usePostStore } from "@/store/non-persisted/post/usePostStore";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { MenuItem } from "@headlessui/react";
 import { ChatBubbleBottomCenterTextIcon } from "@heroicons/react/24/outline";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { PostFragment } from "@hey/indexer";
 import { toast } from "sonner";
 
@@ -28,7 +28,7 @@ const Quote = ({ post }: QuoteProps) => {
       }
       onClick={() => {
         if (!currentAccount) {
-          return toast.error(Errors.SignWallet);
+          return toast.error(ERRORS.SignWallet);
         }
         setQuotedPost(post);
         setShowNewPostModal(true);

--- a/apps/web/src/components/Post/Actions/Share/Repost.tsx
+++ b/apps/web/src/components/Post/Actions/Share/Repost.tsx
@@ -5,7 +5,7 @@ import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { useApolloClient } from "@apollo/client";
 import { MenuItem } from "@headlessui/react";
 import { ArrowsRightLeftIcon } from "@heroicons/react/24/outline";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import { type PostFragment, useRepostMutation } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
 import { useCounter } from "@uidotdev/usehooks";
@@ -82,7 +82,7 @@ const Repost = ({ isSubmitting, post, setIsSubmitting }: RepostProps) => {
 
   const handleCreateRepost = async () => {
     if (!currentAccount) {
-      return toast.error(Errors.SignWallet);
+      return toast.error(ERRORS.SignWallet);
     }
 
     setIsSubmitting(true);

--- a/apps/web/src/components/Post/Actions/Share/UndoRepost.tsx
+++ b/apps/web/src/components/Post/Actions/Share/UndoRepost.tsx
@@ -5,7 +5,7 @@ import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { useApolloClient } from "@apollo/client";
 import { MenuItem } from "@headlessui/react";
 import { ArrowsRightLeftIcon } from "@heroicons/react/24/outline";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import { isRepost } from "@hey/helpers/postHelpers";
 import { type AnyPostFragment, useDeletePostMutation } from "@hey/indexer";
 import type { Dispatch, SetStateAction } from "react";
@@ -67,7 +67,7 @@ const UndoRepost = ({
 
   const handleUndoRepost = async () => {
     if (!currentAccount) {
-      return toast.error(Errors.SignWallet);
+      return toast.error(ERRORS.SignWallet);
     }
 
     setIsSubmitting(true);

--- a/apps/web/src/components/Settings/Developer/Tokens.tsx
+++ b/apps/web/src/components/Settings/Developer/Tokens.tsx
@@ -4,7 +4,7 @@ import errorToast from "@/helpers/errorToast";
 import useCopyToClipboard from "@/hooks/useCopyToClipboard";
 import useHandleWrongNetwork from "@/hooks/useHandleWrongNetwork";
 import { hydrateAuthTokens } from "@/store/persisted/useAuthStore";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import { useAuthenticateMutation, useChallengeMutation } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
 import { useState } from "react";
@@ -51,7 +51,7 @@ const Tokens = () => {
       });
 
       if (!challenge?.data?.challenge?.text) {
-        return toast.error(Errors.SomethingWentWrong);
+        return toast.error(ERRORS.SomethingWentWrong);
       }
 
       // Get signature

--- a/apps/web/src/components/Settings/Manager/AccountManager/AddAccountManager.tsx
+++ b/apps/web/src/components/Settings/Manager/AccountManager/AddAccountManager.tsx
@@ -5,7 +5,7 @@ import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { ADDRESS_PLACEHOLDER } from "@hey/data/constants";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import { useAddAccountManagerMutation } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
 import type { Dispatch, SetStateAction } from "react";
@@ -53,7 +53,7 @@ const AddAccountManager = ({
 
   const handleAddManager = async () => {
     if (!currentAccount) {
-      return toast.error(Errors.SignWallet);
+      return toast.error(ERRORS.SignWallet);
     }
 
     setIsSubmitting(true);

--- a/apps/web/src/components/Settings/Manager/AccountManager/Managers/List.tsx
+++ b/apps/web/src/components/Settings/Manager/AccountManager/Managers/List.tsx
@@ -7,7 +7,7 @@ import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { useApolloClient } from "@apollo/client";
 import { UserCircleIcon } from "@heroicons/react/24/outline";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import {
   type AccountManagerFragment,
   type AccountManagersRequest,
@@ -65,7 +65,7 @@ const List = () => {
 
   const handleRemoveManager = async (manager: AccountManagerFragment) => {
     if (!currentAccount) {
-      return toast.error(Errors.SignWallet);
+      return toast.error(ERRORS.SignWallet);
     }
 
     setRemovingManager(manager);

--- a/apps/web/src/components/Settings/Personalize/Form.tsx
+++ b/apps/web/src/components/Settings/Personalize/Form.tsx
@@ -18,7 +18,7 @@ import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import useWaitForTransactionToComplete from "@/hooks/useWaitForTransactionToComplete";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { BANNER_IDS } from "@hey/data/constants";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import { Regex } from "@hey/data/regex";
 import { useMeLazyQuery, useSetAccountMetadataMutation } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
@@ -122,7 +122,7 @@ const PersonalizeSettingsForm = () => {
     coverUrl: string | undefined
   ) => {
     if (!currentAccount) {
-      return toast.error(Errors.SignWallet);
+      return toast.error(ERRORS.SignWallet);
     }
 
     setIsSubmitting(true);

--- a/apps/web/src/components/Shared/Account/SwitchAccounts.tsx
+++ b/apps/web/src/components/Shared/Account/SwitchAccounts.tsx
@@ -4,7 +4,7 @@ import errorToast from "@/helpers/errorToast";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { signIn, signOut } from "@/store/persisted/useAuthStore";
 import { CheckCircleIcon } from "@heroicons/react/24/solid";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import {
   ManagedAccountsVisibility,
   useAccountsAvailableQuery,
@@ -72,7 +72,7 @@ const SwitchAccounts = () => {
         return location.reload();
       }
 
-      return onError({ message: Errors.SomethingWentWrong });
+      return onError({ message: ERRORS.SomethingWentWrong });
     } catch {
       onError();
     }

--- a/apps/web/src/components/Shared/Alert/BlockOrUnblockAccount.tsx
+++ b/apps/web/src/components/Shared/Alert/BlockOrUnblockAccount.tsx
@@ -4,7 +4,7 @@ import useTransactionLifecycle from "@/hooks/useTransactionLifecycle";
 import { useBlockAlertStore } from "@/store/non-persisted/alert/useBlockAlertStore";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { useApolloClient } from "@apollo/client";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import getAccount from "@hey/helpers/getAccount";
 import { useBlockMutation, useUnblockMutation } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
@@ -85,7 +85,7 @@ const BlockOrUnblockAccount = () => {
 
   const blockOrUnblock = async () => {
     if (!currentAccount) {
-      return toast.error(Errors.SignWallet);
+      return toast.error(ERRORS.SignWallet);
     }
 
     setIsSubmitting(true);

--- a/apps/web/src/components/Shared/Alert/MuteOrUnmuteAccount.tsx
+++ b/apps/web/src/components/Shared/Alert/MuteOrUnmuteAccount.tsx
@@ -3,7 +3,7 @@ import errorToast from "@/helpers/errorToast";
 import { useMuteAlertStore } from "@/store/non-persisted/alert/useMuteAlertStore";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { useApolloClient } from "@apollo/client";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import getAccount from "@hey/helpers/getAccount";
 import { useMuteMutation, useUnmuteMutation } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
@@ -60,7 +60,7 @@ const MuteOrUnmuteAccount = () => {
 
   const muteOrUnmute = async () => {
     if (!currentAccount) {
-      return toast.error(Errors.SignWallet);
+      return toast.error(ERRORS.SignWallet);
     }
 
     setIsSubmitting(true);

--- a/apps/web/src/components/Shared/Auth/Login.tsx
+++ b/apps/web/src/components/Shared/Auth/Login.tsx
@@ -4,7 +4,7 @@ import { signIn } from "@/store/persisted/useAuthStore";
 import { EXPANSION_EASE } from "@/variants";
 import { KeyIcon } from "@heroicons/react/24/outline";
 import { HEY_APP, IS_MAINNET } from "@hey/data/constants";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import {
   type ChallengeRequest,
   ManagedAccountsVisibility,
@@ -97,7 +97,7 @@ const Login = ({ setHasAccounts }: LoginProps) => {
       });
 
       if (!challenge?.data?.challenge?.text) {
-        return toast.error(Errors.SomethingWentWrong);
+        return toast.error(ERRORS.SomethingWentWrong);
       }
 
       // Get signature
@@ -117,7 +117,7 @@ const Login = ({ setHasAccounts }: LoginProps) => {
         return location.reload();
       }
 
-      return onError({ message: Errors.SomethingWentWrong });
+      return onError({ message: ERRORS.SomethingWentWrong });
     } catch {
       onError();
     }
@@ -129,7 +129,7 @@ const Login = ({ setHasAccounts }: LoginProps) => {
         {errorChallenge || errorAuthenticate ? (
           <ErrorMessage
             className="text-red-500"
-            title={Errors.SomethingWentWrong}
+            title={ERRORS.SomethingWentWrong}
             error={errorChallenge || errorAuthenticate}
           />
         ) : null}

--- a/apps/web/src/components/Shared/Auth/Signup/ChooseUsername.tsx
+++ b/apps/web/src/components/Shared/Auth/Signup/ChooseUsername.tsx
@@ -9,7 +9,7 @@ import {
   FaceSmileIcon
 } from "@heroicons/react/24/outline";
 import { HEY_APP, IS_MAINNET } from "@hey/data/constants";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import { Regex } from "@hey/data/regex";
 import {
   useAccountQuery,
@@ -100,7 +100,7 @@ const ChooseUsername = () => {
       });
 
       if (!challenge?.data?.challenge?.text) {
-        return toast.error(Errors.SomethingWentWrong);
+        return toast.error(ERRORS.SomethingWentWrong);
       }
 
       // Get signature
@@ -140,7 +140,7 @@ const ChooseUsername = () => {
         });
       }
 
-      return onError({ message: Errors.SomethingWentWrong });
+      return onError({ message: ERRORS.SomethingWentWrong });
     } catch {
       onError();
     } finally {

--- a/apps/web/src/components/Shared/Auth/Signup/Success.tsx
+++ b/apps/web/src/components/Shared/Auth/Signup/Success.tsx
@@ -2,7 +2,7 @@ import { H4, Image } from "@/components/Shared/UI";
 import errorToast from "@/helpers/errorToast";
 import { signIn } from "@/store/persisted/useAuthStore";
 import { STATIC_IMAGES_URL } from "@hey/data/constants";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import { useSwitchAccountMutation } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
 import { useEffect } from "react";
@@ -31,9 +31,9 @@ const Success = () => {
         return location.reload();
       }
 
-      return onError({ message: Errors.SomethingWentWrong });
+      return onError({ message: ERRORS.SomethingWentWrong });
     } catch {
-      onError({ message: Errors.SomethingWentWrong });
+      onError({ message: ERRORS.SomethingWentWrong });
     }
   };
 

--- a/apps/web/src/components/Shared/EmojiPicker/List.tsx
+++ b/apps/web/src/components/Shared/EmojiPicker/List.tsx
@@ -3,7 +3,7 @@ import cn from "@/helpers/cn";
 import stopEventPropagation from "@/helpers/stopEventPropagation";
 import useEmojis from "@/hooks/prosekit/useEmojis";
 import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import type { Emoji } from "@hey/types/misc";
 import type { ChangeEvent, MouseEvent } from "react";
 import { useEffect, useRef, useState } from "react";
@@ -42,9 +42,9 @@ const List = ({ setEmoji }: ListProps) => {
         className="m-5"
         error={{
           message: "Error while loading emojis",
-          name: Errors.SomethingWentWrong
+          name: ERRORS.SomethingWentWrong
         }}
-        title={Errors.SomethingWentWrong}
+        title={ERRORS.SomethingWentWrong}
       />
     );
   }

--- a/apps/web/src/helpers/errorToast.ts
+++ b/apps/web/src/helpers/errorToast.ts
@@ -1,4 +1,4 @@
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import { toast } from "sonner";
 
 const FORBIDDEN_ERROR_PREFIX =
@@ -38,7 +38,7 @@ const errorToast = (error?: unknown): void => {
     return;
   }
 
-  toast.error(message || Errors.SomethingWentWrong, { id: "error" });
+  toast.error(message || ERRORS.SomethingWentWrong, { id: "error" });
 };
 
 export default errorToast;

--- a/apps/web/src/helpers/uploadMetadata.ts
+++ b/apps/web/src/helpers/uploadMetadata.ts
@@ -1,5 +1,5 @@
 import { CHAIN } from "@hey/data/constants";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import { immutable } from "@lens-chain/storage-client";
 import { storageClient } from "./storageClient";
 
@@ -17,7 +17,7 @@ const uploadMetadata = async (
 
     return uri;
   } catch {
-    throw new Error(Errors.SomethingWentWrong);
+    throw new Error(ERRORS.SomethingWentWrong);
   }
 };
 

--- a/apps/web/src/hooks/useImageCropUpload.tsx
+++ b/apps/web/src/hooks/useImageCropUpload.tsx
@@ -6,7 +6,7 @@ import {
   STATIC_IMAGES_URL,
   type TRANSFORMS
 } from "@hey/data/constants";
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import imageKit from "@hey/helpers/imageKit";
 import sanitizeDStorageUrl from "@hey/helpers/sanitizeDStorageUrl";
 import type { ApolloClientError } from "@hey/types/errors";
@@ -48,7 +48,7 @@ const useImageCropUpload = ({
       const croppedImage = await getCroppedImg(pictureSrc, area);
 
       if (!croppedImage) {
-        return toast.error(Errors.SomethingWentWrong);
+        return toast.error(ERRORS.SomethingWentWrong);
       }
 
       const decentralizedUrl = await uploadCroppedImage(croppedImage);

--- a/apps/web/src/hooks/useTransactionLifecycle.tsx
+++ b/apps/web/src/hooks/useTransactionLifecycle.tsx
@@ -1,4 +1,4 @@
-import { Errors } from "@hey/data/errors";
+import { ERRORS } from "@hey/data/errors";
 import getTransactionData from "@hey/helpers/getTransactionData";
 import type { ApolloClientError } from "@hey/types/errors";
 import { sendEip712Transaction, sendTransaction } from "viem/zksync";
@@ -58,7 +58,7 @@ const useTransactionLifecycle = () => {
         case "TransactionWillFail":
           return onError({ message: transactionData.reason });
         default:
-          throw onError({ message: Errors.SomethingWentWrong });
+          throw onError({ message: ERRORS.SomethingWentWrong });
       }
     } catch (error) {
       return onError(error);

--- a/packages/data/errors.ts
+++ b/packages/data/errors.ts
@@ -1,4 +1,6 @@
-export enum Errors {
-  SignWallet = "Please sign in your wallet.",
-  SomethingWentWrong = "Something went wrong!"
-}
+export const ERRORS = {
+  SignWallet: "Please sign in your wallet.",
+  SomethingWentWrong: "Something went wrong!"
+} as const;
+
+export type ErrorMessage = (typeof ERRORS)[keyof typeof ERRORS];


### PR DESCRIPTION
## Summary
- replace the `Errors` enum with an `ERRORS` object and add an `ErrorMessage` type
- update all imports and references to use the new object

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d9f84127c83308173bf56a3d5c8b9