### PR TITLE
Refactor enums to constants with union types

### DIFF
--- a/apps/web/src/hooks/useImageCropUpload.tsx
+++ b/apps/web/src/hooks/useImageCropUpload.tsx
@@ -4,7 +4,7 @@ import errorToast from "@/helpers/errorToast";
 import {
   DEFAULT_AVATAR,
   STATIC_IMAGES_URL,
-  type TRANSFORMS
+  type Transform
 } from "@hey/data/constants";
 import { Errors } from "@hey/data/errors";
 import imageKit from "@hey/helpers/imageKit";
@@ -19,7 +19,7 @@ interface UseImageCropUploadProps {
   src: string;
   setSrc: (src: string) => void;
   aspect: number;
-  transform: TRANSFORMS;
+  transform: Transform;
   label: "avatar" | "cover";
 }
 

--- a/packages/data/constants.ts
+++ b/packages/data/constants.ts
@@ -57,20 +57,26 @@ export const WRAPPED_NATIVE_TOKEN_SYMBOL = IS_MAINNET ? "WGHO" : "WGRASS";
 export const MAX_IMAGE_UPLOAD = 8;
 
 // Named transforms for ImageKit
-export enum TRANSFORMS {
-  AVATAR_BIG = "tr:w-350,h-350",
-  AVATAR_SMALL = "tr:w-100,h-100",
-  AVATAR_TINY = "tr:w-50,h-50",
-  EXPANDED_AVATAR = "tr:w-1000,h-1000",
-  COVER = "tr:w-1350,h-350",
-  ATTACHMENT = "tr:w-1000"
-}
+export const TRANSFORMS = {
+  AVATAR_BIG: "tr:w-350,h-350",
+  AVATAR_SMALL: "tr:w-100,h-100",
+  AVATAR_TINY: "tr:w-50,h-50",
+  EXPANDED_AVATAR: "tr:w-1000,h-1000",
+  COVER: "tr:w-1350,h-350",
+  ATTACHMENT: "tr:w-1000"
+} as const;
 
-export enum BANNER_IDS {
-  PRO = "108325599858337195593675454288445399104045325554183036578573525280972584660299"
-}
+export type Transform = (typeof TRANSFORMS)[keyof typeof TRANSFORMS];
 
-export enum PERMISSIONS {
-  SUBSCRIPTION = "0x4BE5b4519814A57E6f9AaFC6afBB37eAEeE35aA3",
-  STAFF = "0xA7f2835e54998c6d7d4A0126eC0ebE91b5E43c69"
-}
+export const BANNER_IDS = {
+  PRO: "108325599858337195593675454288445399104045325554183036578573525280972584660299"
+} as const;
+
+export type BannerId = (typeof BANNER_IDS)[keyof typeof BANNER_IDS];
+
+export const PERMISSIONS = {
+  SUBSCRIPTION: "0x4BE5b4519814A57E6f9AaFC6afBB37eAEeE35aA3",
+  STAFF: "0xA7f2835e54998c6d7d4A0126eC0ebE91b5E43c69"
+} as const;
+
+export type Permission = (typeof PERMISSIONS)[keyof typeof PERMISSIONS];

--- a/packages/helpers/getAvatar.ts
+++ b/packages/helpers/getAvatar.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_AVATAR, TRANSFORMS } from "@hey/data/constants";
+import {
+  DEFAULT_AVATAR,
+  TRANSFORMS,
+  type Transform
+} from "@hey/data/constants";
 import imageKit from "./imageKit";
 import sanitizeDStorageUrl from "./sanitizeDStorageUrl";
 
@@ -11,7 +15,7 @@ interface EntityWithAvatar {
 
 const getAvatar = (
   entity: EntityWithAvatar | null | undefined,
-  namedTransform = TRANSFORMS.AVATAR_SMALL
+  namedTransform: Transform = TRANSFORMS.AVATAR_SMALL
 ): string => {
   if (!entity) {
     return DEFAULT_AVATAR;


### PR DESCRIPTION
## Summary
- replace `TRANSFORMS`, `BANNER_IDS` and `PERMISSIONS` enums with constant objects
- expose `Transform`, `BannerId` and `Permission` union types
- update `useImageCropUpload` and `getAvatar` to use new types

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d9f88718c83309183142925f06d40