### PR TITLE
Add children prop to PreferencesProvider

### DIFF
--- a/apps/web/src/components/Common/Providers/PreferencesProvider.tsx
+++ b/apps/web/src/components/Common/Providers/PreferencesProvider.tsx
@@ -2,9 +2,14 @@ import { hono } from "@/helpers/fetcher";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { usePreferencesStore } from "@/store/persisted/usePreferencesStore";
 import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 import { useEffect } from "react";
 
-const PreferencesProvider = () => {
+interface PreferencesProviderProps {
+  children: ReactNode;
+}
+
+const PreferencesProvider = ({ children }: PreferencesProviderProps) => {
   const { currentAccount } = useAccountStore();
   const { setAppIcon, setIncludeLowScore } = usePreferencesStore();
 
@@ -21,7 +26,7 @@ const PreferencesProvider = () => {
     }
   }, [preferences]);
 
-  return null;
+  return <>{children}</>;
 };
 
 export default PreferencesProvider;

--- a/apps/web/src/components/Common/Providers/index.tsx
+++ b/apps/web/src/components/Common/Providers/index.tsx
@@ -24,8 +24,9 @@ const Providers = ({ children }: ProvidersProps) => {
       <QueryClientProvider client={queryClient}>
         <Web3Provider>
           <ApolloProvider client={lensApolloClient}>
-            <PreferencesProvider />
-            <ThemeProvider>{children}</ThemeProvider>
+            <PreferencesProvider>
+              <ThemeProvider>{children}</ThemeProvider>
+            </PreferencesProvider>
           </ApolloProvider>
         </Web3Provider>
       </QueryClientProvider>


### PR DESCRIPTION
## Summary
- let `PreferencesProvider` accept `children`
- wrap `ThemeProvider` in `PreferencesProvider`

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d9f61bac48330ba227b8c4ebfcd6b