### PR TITLE
Fix middleware context typing in tests

### DIFF
--- a/apps/web/functions/_middleware.test.ts
+++ b/apps/web/functions/_middleware.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { onRequest } from "./_middleware";
+import { type Context, onRequest } from "./_middleware";
 
 const createResponse = () =>
   new Response("ok", { status: 200, headers: { x: "y" } });
@@ -10,7 +10,7 @@ const stubFetch = () => {
   return fetchMock;
 };
 
-const createContext = (url: string, ua = "") => {
+const createContext = (url: string, ua = ""): Context => {
   const headers = new Headers();
   if (ua) headers.set("user-agent", ua);
   const request = new Request(url, { headers });
@@ -26,7 +26,7 @@ describe("onRequest middleware", () => {
   it("rewrites sitemap root", async () => {
     const fetchMock = stubFetch();
     const ctx = createContext("https://hey.xyz/sitemap.xml");
-    const res = await onRequest(ctx as any);
+    const res = await onRequest(ctx);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.hey.xyz/sitemap/all.xml",
@@ -38,7 +38,7 @@ describe("onRequest middleware", () => {
   it("rewrites sitemap paths", async () => {
     const fetchMock = stubFetch();
     const ctx = createContext("https://hey.xyz/sitemap/posts.xml");
-    await onRequest(ctx as any);
+    await onRequest(ctx);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.hey.xyz/sitemap/posts.xml",
@@ -49,7 +49,7 @@ describe("onRequest middleware", () => {
   it("rewrites og paths for bots", async () => {
     const fetchMock = stubFetch();
     const ctx = createContext("https://hey.xyz/posts/123", "Googlebot");
-    await onRequest(ctx as any);
+    await onRequest(ctx);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.hey.xyz/og/posts/123",

--- a/apps/web/functions/_middleware.ts
+++ b/apps/web/functions/_middleware.ts
@@ -1,4 +1,4 @@
-interface Context {
+export interface Context {
   request: Request;
   next: () => Promise<Response>;
 }


### PR DESCRIPTION
## Summary
- export Context interface from middleware
- use Context type in middleware tests

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d9fea7c148330b091f4fa928fd306