### PR TITLE
Refactor account props usage

### DIFF
--- a/apps/web/src/components/Account/index.tsx
+++ b/apps/web/src/components/Account/index.tsx
@@ -70,6 +70,8 @@ const ViewAccount = () => {
   const isBlockedByMe = account?.operations?.isBlockedByMe;
   const hasBlockedMe = account?.operations?.hasBlockedMe;
 
+  const accountInfo = getAccount(account);
+
   const renderAccountDetails = () => {
     if (isDeleted) return <DeletedDetails account={account} />;
 
@@ -101,7 +103,7 @@ const ViewAccount = () => {
 
   return (
     <PageLayout
-      title={`${getAccount(account).name} (${getAccount(account).usernameWithPrefix}) • Hey`}
+      title={`${accountInfo.name} (${accountInfo.usernameWithPrefix}) • Hey`}
       zeroTopMargin
     >
       <Cover
@@ -122,7 +124,7 @@ const ViewAccount = () => {
             feedType === AccountFeedType.Media ||
             feedType === AccountFeedType.Collects) && (
             <AccountFeed
-              username={getAccount(account).usernameWithPrefix}
+              username={accountInfo.usernameWithPrefix}
               address={account.address}
               type={feedType}
             />


### PR DESCRIPTION
## Summary
- compute account info once and reuse it in `Account` component

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684da00f84288330a030d020b679bc29