### PR TITLE
Use arrow functions in prosekit helper

### DIFF
--- a/apps/web/src/helpers/prosekit/rehypeJoinParagraph.ts
+++ b/apps/web/src/helpers/prosekit/rehypeJoinParagraph.ts
@@ -3,27 +3,27 @@ import type { Element, Node, Parent, Root } from "hast";
 import type { Plugin } from "unified";
 import { visitParents } from "unist-util-visit-parents";
 
-function isParent(node: Node): node is Parent {
+const isParent = (node: Node): node is Parent => {
   return "children" in node && Array.isArray(node.children);
-}
+};
 
 interface Paragraph extends Element {
   tagName: "p";
 }
 
-function isElement(node: Node): node is Element {
+const isElement = (node: Node): node is Element => {
   return node.type === "element";
-}
+};
 
-function isParagraph(node: Node): node is Paragraph {
+const isParagraph = (node: Node): node is Paragraph => {
   return isElement(node) && node.tagName.toLowerCase() === "p";
-}
+};
 
-function isParagraphEmpty(node: Paragraph): boolean {
+const isParagraphEmpty = (node: Paragraph): boolean => {
   return node.children.length === 0;
-}
+};
 
-function joinParagraphs(a: Paragraph, b: Paragraph): Paragraph {
+const joinParagraphs = (a: Paragraph, b: Paragraph): Paragraph => {
   const br: Element = {
     type: "element",
     tagName: "br",
@@ -37,9 +37,9 @@ function joinParagraphs(a: Paragraph, b: Paragraph): Paragraph {
     properties: { ...a.properties, ...b.properties },
     children: [...a.children, br, ...b.children]
   };
-}
+};
 
-function joinChildren<T extends Node>(children: T[]): T[] {
+const joinChildren = <T extends Node>(children: T[]): T[] => {
   const result: T[] = [];
 
   for (const child of children) {
@@ -58,7 +58,7 @@ function joinChildren<T extends Node>(children: T[]): T[] {
   }
 
   return result;
-}
+};
 
 const rehypeJoinParagraphTransformer = (root: Root): Root => {
   visitParents(root, (node) => {


### PR DESCRIPTION
## Summary
- refactor helper functions to arrow function syntax

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684dabe9c9a48330a80f843fb6d3bf64