### PR TITLE
chore(ci): update pnpm action to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
Replaced deprecated `pnpm/action-setup@v2` with the latest `pnpm/setup-action@v4`.
This ensures compatibility with Node.js 20+ and removes deprecation warnings in CI.