### PR TITLE
Centralize dayjs setup

### DIFF
--- a/apps/web/src/helpers/datetime/dayjs.ts
+++ b/apps/web/src/helpers/datetime/dayjs.ts
@@ -1,0 +1,6 @@
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+
+dayjs.extend(relativeTime);
+
+export default dayjs;

--- a/apps/web/src/helpers/datetime/formatDate.ts
+++ b/apps/web/src/helpers/datetime/formatDate.ts
@@ -1,7 +1,4 @@
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-
-dayjs.extend(relativeTime);
+import dayjs from "./dayjs";
 
 const formatDate = (date: Date | string, format = "MMMM D, YYYY") => {
   return dayjs(new Date(date)).format(format);

--- a/apps/web/src/helpers/datetime/formatRelativeOrAbsolute.ts
+++ b/apps/web/src/helpers/datetime/formatRelativeOrAbsolute.ts
@@ -1,7 +1,4 @@
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-
-dayjs.extend(relativeTime);
+import dayjs from "./dayjs";
 
 const formatRelativeOrAbsolute = (date: Date | string) => {
   const now = dayjs();

--- a/apps/web/src/helpers/datetime/getNumberOfDaysFromDate.ts
+++ b/apps/web/src/helpers/datetime/getNumberOfDaysFromDate.ts
@@ -1,7 +1,4 @@
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-
-dayjs.extend(relativeTime);
+import dayjs from "./dayjs";
 
 const getNumberOfDaysFromDate = (date: Date) => {
   const currentDate = dayjs().startOf("day");

--- a/apps/web/src/helpers/datetime/getTimeAddedNDay.ts
+++ b/apps/web/src/helpers/datetime/getTimeAddedNDay.ts
@@ -1,8 +1,6 @@
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
+import dayjs from "./dayjs";
 
-dayjs.extend(relativeTime);
 dayjs.extend(utc);
 
 const getTimeAddedNDay = (day: number) => {


### PR DESCRIPTION
## Summary
- add a shared dayjs helper that configures the `relativeTime` plugin
- refactor datetime helpers to use the shared instance

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68539807fc8c8330a8c60075b0a32d17