### PR TITLE
Refactor sitemap routes with caching utility

### DIFF
--- a/apps/api/src/routes/sitemap/accounts/accountSitemap.test.ts
+++ b/apps/api/src/routes/sitemap/accounts/accountSitemap.test.ts
@@ -16,9 +16,9 @@ beforeEach(() => {
 });
 
 describe("accountSitemap", () => {
-  it("returns cached usernames when available", async () => {
+  it("returns cached xml when available", async () => {
     (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
-      '["bob"]'
+      "<xml/>"
     );
     const header = vi.fn();
     const body = vi.fn((c: unknown) => c);
@@ -31,7 +31,7 @@ describe("accountSitemap", () => {
     const result = await accountSitemap(ctx);
 
     expect(body).toHaveBeenCalled();
-    expect(result).toContain("https://hey.xyz/u/bob");
+    expect(result).toBe("<xml/>");
     expect(lensPg.query).not.toHaveBeenCalled();
     expect(setRedis).not.toHaveBeenCalled();
   });

--- a/apps/api/src/routes/sitemap/accounts/accountsGroupSitemap.test.ts
+++ b/apps/api/src/routes/sitemap/accounts/accountsGroupSitemap.test.ts
@@ -17,7 +17,9 @@ beforeEach(() => {
 
 describe("accountsGroupSitemap", () => {
   it("returns cached value when available", async () => {
-    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue("2");
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "<sitemapindex/>"
+    );
     const header = vi.fn();
     const body = vi.fn((c: unknown) => c);
     const ctx = {

--- a/apps/api/src/routes/sitemap/accounts/accountsGroupSitemap.ts
+++ b/apps/api/src/routes/sitemap/accounts/accountsGroupSitemap.ts
@@ -4,6 +4,7 @@ import { SITEMAP_BATCH_SIZE, SITEMAP_CACHE_DAYS } from "src/utils/constants";
 import lensPg from "src/utils/lensPg";
 import { getRedis, hoursToSeconds, setRedis } from "src/utils/redis";
 import { create } from "xmlbuilder2";
+import generateSitemap from "../common";
 
 const accountsGroupSitemap = async (ctx: Context) => {
   const params = ctx.req.param();
@@ -15,56 +16,57 @@ const accountsGroupSitemap = async (ctx: Context) => {
 
   const group = Number(groupParam);
 
-  try {
-    const cacheKey = "sitemap:accounts:total";
-    const cachedData = await getRedis(cacheKey);
-    let totalBatches: number;
+  return generateSitemap({
+    ctx,
+    cacheKey: `sitemap:accounts:group:${group}`,
+    buildXml: async () => {
+      const cacheKey = "sitemap:accounts:total";
+      const cachedData = await getRedis(cacheKey);
+      let totalBatches: number;
 
-    if (cachedData) {
-      totalBatches = Number(cachedData);
-    } else {
-      const usernames = (await lensPg.query(
-        `
+      if (cachedData) {
+        totalBatches = Number(cachedData);
+      } else {
+        const usernames = (await lensPg.query(
+          `
           SELECT CEIL(COUNT(*) / $1) AS count
           FROM account.username_assigned;
         `,
-        [SITEMAP_BATCH_SIZE]
-      )) as Array<{ count: number }>;
+          [SITEMAP_BATCH_SIZE]
+        )) as Array<{ count: number }>;
 
-      totalBatches = Number(usernames[0]?.count) || 0;
-      await setRedis(
-        cacheKey,
-        totalBatches,
-        hoursToSeconds(SITEMAP_CACHE_DAYS * 24)
+        totalBatches = Number(usernames[0]?.count) || 0;
+        await setRedis(
+          cacheKey,
+          totalBatches,
+          hoursToSeconds(SITEMAP_CACHE_DAYS * 24)
+        );
+      }
+
+      const startBatch = (group - 1) * SITEMAP_BATCH_SIZE;
+      const endBatch = Math.min(startBatch + SITEMAP_BATCH_SIZE, totalBatches);
+
+      const sitemapIndex = create({ version: "1.0", encoding: "UTF-8" }).ele(
+        "sitemapindex",
+        { xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9" }
       );
+
+      for (let i = startBatch; i < endBatch; i++) {
+        sitemapIndex
+          .ele("sitemap")
+          .ele("loc")
+          .txt(
+            `https://hey.xyz/sitemap/accounts/${group}/${i - startBatch + 1}.xml`
+          )
+          .up()
+          .ele("lastmod")
+          .txt(new Date().toISOString())
+          .up();
+      }
+
+      return sitemapIndex.end({ prettyPrint: true });
     }
-
-    const startBatch = (group - 1) * SITEMAP_BATCH_SIZE;
-    const endBatch = Math.min(startBatch + SITEMAP_BATCH_SIZE, totalBatches);
-
-    const sitemapIndex = create({ version: "1.0", encoding: "UTF-8" }).ele(
-      "sitemapindex",
-      { xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9" }
-    );
-
-    for (let i = startBatch; i < endBatch; i++) {
-      sitemapIndex
-        .ele("sitemap")
-        .ele("loc")
-        .txt(
-          `https://hey.xyz/sitemap/accounts/${group}/${i - startBatch + 1}.xml`
-        )
-        .up()
-        .ele("lastmod")
-        .txt(new Date().toISOString())
-        .up();
-    }
-
-    ctx.header("Content-Type", "application/xml");
-    return ctx.body(sitemapIndex.end({ prettyPrint: true }));
-  } catch {
-    return ctx.body(ERRORS.SomethingWentWrong);
-  }
+  });
 };
 
 export default accountsGroupSitemap;

--- a/apps/api/src/routes/sitemap/accounts/accountsSitemapIndex.test.ts
+++ b/apps/api/src/routes/sitemap/accounts/accountsSitemapIndex.test.ts
@@ -17,7 +17,9 @@ beforeEach(() => {
 
 describe("accountsSitemapIndex", () => {
   it("returns cached value when available", async () => {
-    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue("2");
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "<sitemapindex/>"
+    );
     const header = vi.fn();
     const body = vi.fn((c: unknown) => c);
     const ctx = { header, body } as unknown as Context;

--- a/apps/api/src/routes/sitemap/accounts/accountsSitemapIndex.ts
+++ b/apps/api/src/routes/sitemap/accounts/accountsSitemapIndex.ts
@@ -1,58 +1,58 @@
-import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 import { SITEMAP_BATCH_SIZE, SITEMAP_CACHE_DAYS } from "src/utils/constants";
 import lensPg from "src/utils/lensPg";
 import { getRedis, hoursToSeconds, setRedis } from "src/utils/redis";
 import { create } from "xmlbuilder2";
+import generateSitemap from "../common";
 
-const accountsSitemapIndex = async (ctx: Context) => {
-  try {
-    const cacheKey = "sitemap:accounts:total";
-    const cachedData = await getRedis(cacheKey);
-    let totalBatches: number;
+const accountsSitemapIndex = async (ctx: Context) =>
+  generateSitemap({
+    ctx,
+    cacheKey: "sitemap:accounts:index",
+    buildXml: async () => {
+      const cacheKey = "sitemap:accounts:total";
+      const cachedData = await getRedis(cacheKey);
+      let totalBatches: number;
 
-    if (cachedData) {
-      totalBatches = Number(cachedData);
-    } else {
-      const usernames = (await lensPg.query(
-        `
+      if (cachedData) {
+        totalBatches = Number(cachedData);
+      } else {
+        const usernames = (await lensPg.query(
+          `
           SELECT CEIL(COUNT(*) / $1) AS count
           FROM account.username_assigned;
         `,
-        [SITEMAP_BATCH_SIZE]
-      )) as Array<{ count: number }>;
+          [SITEMAP_BATCH_SIZE]
+        )) as Array<{ count: number }>;
 
-      totalBatches = Number(usernames[0]?.count) || 0;
-      await setRedis(
-        cacheKey,
-        totalBatches,
-        hoursToSeconds(SITEMAP_CACHE_DAYS * 24)
+        totalBatches = Number(usernames[0]?.count) || 0;
+        await setRedis(
+          cacheKey,
+          totalBatches,
+          hoursToSeconds(SITEMAP_CACHE_DAYS * 24)
+        );
+      }
+
+      const totalGroups = Math.ceil(totalBatches / SITEMAP_BATCH_SIZE);
+
+      const sitemapIndex = create({ version: "1.0", encoding: "UTF-8" }).ele(
+        "sitemapindex",
+        { xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9" }
       );
+
+      for (let i = 0; i < totalGroups; i++) {
+        sitemapIndex
+          .ele("sitemap")
+          .ele("loc")
+          .txt(`https://hey.xyz/sitemap/accounts/${i + 1}.xml`)
+          .up()
+          .ele("lastmod")
+          .txt(new Date().toISOString())
+          .up();
+      }
+
+      return sitemapIndex.end({ prettyPrint: true });
     }
-
-    const totalGroups = Math.ceil(totalBatches / SITEMAP_BATCH_SIZE);
-
-    const sitemapIndex = create({ version: "1.0", encoding: "UTF-8" }).ele(
-      "sitemapindex",
-      { xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9" }
-    );
-
-    for (let i = 0; i < totalGroups; i++) {
-      sitemapIndex
-        .ele("sitemap")
-        .ele("loc")
-        .txt(`https://hey.xyz/sitemap/accounts/${i + 1}.xml`)
-        .up()
-        .ele("lastmod")
-        .txt(new Date().toISOString())
-        .up();
-    }
-
-    ctx.header("Content-Type", "application/xml");
-    return ctx.body(sitemapIndex.end({ prettyPrint: true }));
-  } catch {
-    return ctx.body(ERRORS.SomethingWentWrong);
-  }
-};
+  });
 
 export default accountsSitemapIndex;

--- a/apps/api/src/routes/sitemap/common.ts
+++ b/apps/api/src/routes/sitemap/common.ts
@@ -1,0 +1,35 @@
+import { ERRORS } from "@hey/data/errors";
+import type { Context } from "hono";
+import { SITEMAP_CACHE_DAYS } from "src/utils/constants";
+import { getRedis, hoursToSeconds, setRedis } from "src/utils/redis";
+
+export interface SitemapHelperOptions {
+  ctx: Context;
+  cacheKey: string;
+  buildXml: () => Promise<string>;
+}
+
+const generateSitemap = async ({
+  ctx,
+  cacheKey,
+  buildXml
+}: SitemapHelperOptions) => {
+  try {
+    const cached = await getRedis(cacheKey);
+    if (cached) {
+      ctx.header("Content-Type", "application/xml");
+      return ctx.body(cached);
+    }
+
+    const xml = await buildXml();
+
+    await setRedis(cacheKey, xml, hoursToSeconds(SITEMAP_CACHE_DAYS * 24));
+
+    ctx.header("Content-Type", "application/xml");
+    return ctx.body(xml);
+  } catch {
+    return ctx.body(ERRORS.SomethingWentWrong);
+  }
+};
+
+export default generateSitemap;


### PR DESCRIPTION
## Summary
- add sitemap caching helper
- use helper in account sitemap routes
- update tests for new helper

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68539cb46bdc83309b7d411b4a294589