### PR TITLE
Change API success flag to status

### DIFF
--- a/apps/api/src/routes/cron/removeExpiredSubscribers/index.test.ts
+++ b/apps/api/src/routes/cron/removeExpiredSubscribers/index.test.ts
@@ -42,7 +42,7 @@ describe("removeExpiredSubscribers", () => {
       ]
     });
     expect(result).toEqual({
-      success: true,
+      status: "success",
       addresses: [`0x${buf.toString("hex")}`],
       hash: "hash"
     });
@@ -55,7 +55,7 @@ describe("removeExpiredSubscribers", () => {
     const result = await removeExpiredSubscribers(ctx);
 
     expect(result).toEqual({
-      success: true,
+      status: "success",
       message: "No expired subscribers"
     });
   });

--- a/apps/api/src/routes/cron/removeExpiredSubscribers/index.ts
+++ b/apps/api/src/routes/cron/removeExpiredSubscribers/index.ts
@@ -23,7 +23,7 @@ const removeExpiredSubscribers = async (ctx: Context) => {
     );
 
     if (addresses.length === 0) {
-      return ctx.json({ success: true, message: "No expired subscribers" });
+      return ctx.json({ status: "success", message: "No expired subscribers" });
     }
 
     const membersToRemove = addresses.map((addr) => ({
@@ -39,7 +39,7 @@ const removeExpiredSubscribers = async (ctx: Context) => {
       args: [membersToRemove, []]
     });
 
-    return ctx.json({ success: true, addresses, hash });
+    return ctx.json({ status: "success", addresses, hash });
   } catch {
     return handleApiError(ctx);
   }

--- a/apps/api/src/routes/jumper/getStats.ts
+++ b/apps/api/src/routes/jumper/getStats.ts
@@ -8,7 +8,7 @@ const getStats = async (ctx: Context) => {
     const { address, post } = await ctx.req.json();
 
     if (!address) {
-      return ctx.json({ success: false, error: "Address is required" }, 400);
+      return ctx.json({ status: "error", error: "Address is required" }, 400);
     }
 
     const accounts = (await lensPg.query(
@@ -54,7 +54,7 @@ const getStats = async (ctx: Context) => {
     );
 
     return ctx.json({
-      success: true,
+      status: "success",
       tips: Number(result[0].count),
       quotes: Number(result[1].count),
       comments: Number(result[2].count)

--- a/apps/api/src/routes/lens/authorization.test.ts
+++ b/apps/api/src/routes/lens/authorization.test.ts
@@ -23,11 +23,11 @@ describe("lens authorization route", () => {
     const ctx = createCtx();
     const result = await authorization(ctx);
     expect(ctx.json).toHaveBeenCalledWith(
-      { success: false, error: "Unauthorized" },
+      { status: "error", error: "Unauthorized" },
       401
     );
     expect(result).toEqual({
-      body: { success: false, error: "Unauthorized" },
+      body: { status: "error", error: "Unauthorized" },
       status: 401
     });
   });
@@ -36,11 +36,11 @@ describe("lens authorization route", () => {
     const ctx = createCtx("Bearer wrong");
     const result = await authorization(ctx);
     expect(ctx.json).toHaveBeenCalledWith(
-      { success: false, error: "Invalid shared secret" },
+      { status: "error", error: "Invalid shared secret" },
       401
     );
     expect(result).toEqual({
-      body: { success: false, error: "Invalid shared secret" },
+      body: { status: "error", error: "Invalid shared secret" },
       status: 401
     });
   });

--- a/apps/api/src/routes/lens/authorization.ts
+++ b/apps/api/src/routes/lens/authorization.ts
@@ -6,13 +6,13 @@ const authorization = async (ctx: Context) => {
     const authHeader = ctx.req.raw.headers.get("authorization");
 
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      return ctx.json({ success: false, error: "Unauthorized" }, 401);
+      return ctx.json({ status: "error", error: "Unauthorized" }, 401);
     }
 
     const token = authHeader.split(" ")[1];
 
     if (token !== process.env.SHARED_SECRET) {
-      return ctx.json({ success: false, error: "Invalid shared secret" }, 401);
+      return ctx.json({ status: "error", error: "Invalid shared secret" }, 401);
     }
 
     return ctx.json({

--- a/apps/api/src/routes/live/createLive.test.ts
+++ b/apps/api/src/routes/live/createLive.test.ts
@@ -17,8 +17,11 @@ describe("live create route", () => {
     const result = await createLive(ctx);
 
     expect(fetchMock).toHaveBeenCalled();
-    expect(ctx.json).toHaveBeenCalledWith({ success: true, data: { id: "1" } });
-    expect(result).toEqual({ success: true, data: { id: "1" } });
+    expect(ctx.json).toHaveBeenCalledWith({
+      status: "success",
+      data: { id: "1" }
+    });
+    expect(result).toEqual({ status: "success", data: { id: "1" } });
 
     vi.unstubAllGlobals();
   });

--- a/apps/api/src/routes/live/createLive.ts
+++ b/apps/api/src/routes/live/createLive.ts
@@ -37,7 +37,7 @@ const createLive = async (ctx: Context) => {
     });
 
     return ctx.json({
-      success: true,
+      status: "success",
       data: (await response.json()) as {
         id: string;
         playbackId: string;

--- a/apps/api/src/routes/metadata/getSTS.test.ts
+++ b/apps/api/src/routes/metadata/getSTS.test.ts
@@ -26,7 +26,7 @@ describe("metadata getSTS route", () => {
     const result = await getSTS(ctx);
 
     expect(ctx.json).toHaveBeenCalledWith({
-      success: true,
+      status: "success",
       data: {
         accessKeyId: "AK",
         secretAccessKey: "SK",
@@ -34,7 +34,7 @@ describe("metadata getSTS route", () => {
       }
     });
     expect(result).toEqual({
-      success: true,
+      status: "success",
       data: { accessKeyId: "AK", secretAccessKey: "SK", sessionToken: "ST" }
     });
   });

--- a/apps/api/src/routes/metadata/getSTS.ts
+++ b/apps/api/src/routes/metadata/getSTS.ts
@@ -34,7 +34,7 @@ const getSTS = async (ctx: Context) => {
     const { Credentials: credentials } = await stsClient.send(command);
 
     return ctx.json({
-      success: true,
+      status: "success",
       data: {
         accessKeyId: credentials?.AccessKeyId,
         secretAccessKey: credentials?.SecretAccessKey,

--- a/apps/api/src/routes/oembed/getOembed.test.ts
+++ b/apps/api/src/routes/oembed/getOembed.test.ts
@@ -40,12 +40,12 @@ describe("oembed getOembed route", () => {
 
     expect(header).toHaveBeenCalledWith("Cache-Control", CACHE_AGE_1_DAY);
     expect(json).toHaveBeenCalledWith({
-      success: true,
+      status: "success",
       cached: true,
       data: { foo: "bar" }
     });
     expect(result).toEqual({
-      success: true,
+      status: "success",
       cached: true,
       data: { foo: "bar" }
     });
@@ -66,11 +66,11 @@ describe("oembed getOembed route", () => {
     expect(getMetadata).toHaveBeenCalledWith("https://x");
     expect(setRedis).toHaveBeenCalled();
     expect(json).toHaveBeenCalledWith({
-      success: true,
+      status: "success",
       data: { title: "Title", description: "Desc", url: "https://x" }
     });
     expect(result).toEqual({
-      success: true,
+      status: "success",
       data: { title: "Title", description: "Desc", url: "https://x" }
     });
   });

--- a/apps/api/src/routes/oembed/getOembed.ts
+++ b/apps/api/src/routes/oembed/getOembed.ts
@@ -15,7 +15,7 @@ const getOembed = async (ctx: Context) => {
 
     if (cachedValue) {
       return ctx.json({
-        success: true,
+        status: "success",
         cached: true,
         data: JSON.parse(cachedValue)
       });
@@ -24,7 +24,7 @@ const getOembed = async (ctx: Context) => {
     const oembed = await getMetadata(url);
     await setRedis(cacheKey, oembed, generateExtraLongExpiry());
 
-    return ctx.json({ success: true, data: oembed });
+    return ctx.json({ status: "success", data: oembed });
   } catch {
     return handleApiError(ctx);
   }

--- a/apps/api/src/routes/preferences/getPreferences.test.ts
+++ b/apps/api/src/routes/preferences/getPreferences.test.ts
@@ -26,12 +26,12 @@ describe("getPreferences route", () => {
     const result = await getPreferences(ctx);
 
     expect(ctx.json).toHaveBeenCalledWith({
-      success: true,
+      status: "success",
       cached: true,
       data: { appIcon: 1, includeLowScore: true }
     });
     expect(result).toEqual({
-      success: true,
+      status: "success",
       cached: true,
       data: { appIcon: 1, includeLowScore: true }
     });
@@ -55,11 +55,11 @@ describe("getPreferences route", () => {
     });
     expect(setRedis).toHaveBeenCalled();
     expect(ctx.json).toHaveBeenCalledWith({
-      success: true,
+      status: "success",
       data: { appIcon: 2, includeLowScore: false }
     });
     expect(result).toEqual({
-      success: true,
+      status: "success",
       data: { appIcon: 2, includeLowScore: false }
     });
   });

--- a/apps/api/src/routes/preferences/getPreferences.ts
+++ b/apps/api/src/routes/preferences/getPreferences.ts
@@ -12,7 +12,7 @@ const getPreferences = async (ctx: Context) => {
 
     if (cachedValue) {
       return ctx.json({
-        success: true,
+        status: "success",
         cached: true,
         data: JSON.parse(cachedValue)
       });
@@ -29,7 +29,7 @@ const getPreferences = async (ctx: Context) => {
 
     await setRedis(cacheKey, data);
 
-    return ctx.json({ success: true, data });
+    return ctx.json({ status: "success", data });
   } catch {
     return handleApiError(ctx);
   }

--- a/apps/api/src/routes/preferences/updatePreferences.test.ts
+++ b/apps/api/src/routes/preferences/updatePreferences.test.ts
@@ -33,11 +33,11 @@ describe("updatePreferences route", () => {
     });
     expect(delRedis).toHaveBeenCalledWith("preferences:0x1");
     expect(ctx.json).toHaveBeenCalledWith({
-      success: true,
+      status: "success",
       data: { appIcon: 3, includeLowScore: true }
     });
     expect(result).toEqual({
-      success: true,
+      status: "success",
       data: { appIcon: 3, includeLowScore: true }
     });
   });

--- a/apps/api/src/routes/preferences/updatePreferences.ts
+++ b/apps/api/src/routes/preferences/updatePreferences.ts
@@ -17,7 +17,7 @@ const updatePreferences = async (ctx: Context) => {
     await delRedis(`preferences:${account}`);
 
     return ctx.json({
-      success: true,
+      status: "success",
       data: {
         appIcon: preference.appIcon ?? 0,
         includeLowScore: preference.includeLowScore ?? false

--- a/apps/api/src/utils/handleApiError.ts
+++ b/apps/api/src/utils/handleApiError.ts
@@ -2,6 +2,6 @@ import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 
 const handleApiError = (ctx: Context): Response =>
-  ctx.json({ success: false, error: ERRORS.SomethingWentWrong }, 500);
+  ctx.json({ status: "error", error: ERRORS.SomethingWentWrong }, 500);
 
 export default handleApiError;

--- a/apps/api/src/utils/syncAddressesToGuild.ts
+++ b/apps/api/src/utils/syncAddressesToGuild.ts
@@ -32,7 +32,7 @@ const syncAddressesToGuild = async ({
   );
 
   return {
-    success: true,
+    status: "success",
     total: addresses.length,
     updatedAt: updatedRequirement.updatedAt
   };

--- a/apps/web/src/helpers/fetcher.ts
+++ b/apps/web/src/helpers/fetcher.ts
@@ -43,7 +43,7 @@ const fetchApi = async <T>(
 
   const result = await response.json();
 
-  if (result.success) {
+  if (result.status === "success") {
     return result.data;
   }
 


### PR DESCRIPTION
## Summary
- replace `success` boolean with `status` string in API responses
- update fetcher to read the new `status` field
- adjust related tests

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6853d656bc708330b9ee210038ed692f