### PR TITLE
Refactor local storage clearing helper

### DIFF
--- a/apps/web/src/components/Shared/SiteError.tsx
+++ b/apps/web/src/components/Shared/SiteError.tsx
@@ -1,4 +1,5 @@
 import { Button, H3 } from "@/components/Shared/UI";
+import clearLocalStorage from "@/helpers/clearLocalStorage";
 
 interface SiteErrorProps {
   message?: string;
@@ -6,7 +7,7 @@ interface SiteErrorProps {
 
 const SiteError = ({ message }: SiteErrorProps) => {
   const clearLocalData = () => {
-    localStorage.clear();
+    clearLocalStorage();
     setTimeout(() => location.reload(), 200);
   };
 

--- a/apps/web/src/helpers/clearLocalStorage.test.ts
+++ b/apps/web/src/helpers/clearLocalStorage.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import clearLocalStorage from "./clearLocalStorage";
+import { Localstorage } from "@hey/data/storage";
+
+describe("clearLocalStorage", () => {
+  beforeEach(() => {
+    (global as any).localStorage = {
+      removeItem: vi.fn()
+    };
+  });
+
+  it("removes all keys except search store", () => {
+    clearLocalStorage();
+
+    const stores = Object.values(Localstorage).filter(
+      (s) => s !== Localstorage.SearchStore
+    );
+
+    for (const store of stores) {
+      expect((global as any).localStorage.removeItem).toHaveBeenCalledWith(store);
+    }
+
+    expect((global as any).localStorage.removeItem).toHaveBeenCalledTimes(
+      stores.length
+    );
+  });
+});

--- a/apps/web/src/helpers/clearLocalStorage.ts
+++ b/apps/web/src/helpers/clearLocalStorage.ts
@@ -1,0 +1,13 @@
+import { Localstorage } from "@hey/data/storage";
+
+const clearLocalStorage = (): void => {
+  const storesToClear = Object.values(Localstorage).filter(
+    (store) => store !== Localstorage.SearchStore
+  );
+
+  for (const store of storesToClear) {
+    localStorage.removeItem(store);
+  }
+};
+
+export default clearLocalStorage;

--- a/apps/web/src/store/persisted/useAuthStore.ts
+++ b/apps/web/src/store/persisted/useAuthStore.ts
@@ -1,5 +1,6 @@
 import { createPersistedTrackedStore } from "@/store/createTrackedStore";
 import { Localstorage } from "@hey/data/storage";
+import clearLocalStorage from "@/helpers/clearLocalStorage";
 
 interface Tokens {
   accessToken: null | string;
@@ -28,13 +29,7 @@ const { store } = createPersistedTrackedStore<State>(
     signIn: ({ accessToken, refreshToken }) =>
       set({ accessToken, refreshToken }),
     signOut: async () => {
-      // Clear Localstorage
-      const allLocalstorageStores = Object.values(Localstorage).filter(
-        (value) => value !== Localstorage.SearchStore
-      );
-      for (const store of allLocalstorageStores) {
-        localStorage.removeItem(store);
-      }
+      clearLocalStorage();
     }
   }),
   { name: Localstorage.AuthStore }


### PR DESCRIPTION
## Summary
- centralize local storage clearing logic
- hook components into new helper
- add unit test for helper

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685508a2be7c8330a5460e6e9b38e81b