### PR TITLE
refactor(web): track post attachment store

### DIFF
--- a/apps/web/src/components/Composer/Actions/Attachment.tsx
+++ b/apps/web/src/components/Composer/Actions/Attachment.tsx
@@ -30,7 +30,7 @@ const VideoMimeType = [
 ];
 
 const Attachment = () => {
-  const { attachments, isUploading } = usePostAttachmentStore((state) => state);
+  const { attachments, isUploading } = usePostAttachmentStore();
   const { handleUploadAttachments } = useUploadAttachments();
   const [showMenu, setShowMenu] = useState(false);
   const id = useId();

--- a/apps/web/src/components/Composer/Actions/Gif/index.tsx
+++ b/apps/web/src/components/Composer/Actions/Gif/index.tsx
@@ -11,7 +11,7 @@ interface GifProps {
 }
 
 const Gif = ({ setGifAttachment }: GifProps) => {
-  const { attachments } = usePostAttachmentStore((state) => state);
+  const { attachments } = usePostAttachmentStore();
   const [showModal, setShowModal] = useState(false);
   const disable =
     attachments.length > 0 &&

--- a/apps/web/src/components/Composer/Actions/LivestreamSettings/index.tsx
+++ b/apps/web/src/components/Composer/Actions/LivestreamSettings/index.tsx
@@ -7,7 +7,7 @@ import { VideoCameraIcon } from "@heroicons/react/24/outline";
 const LivestreamSettings = () => {
   const { resetLiveVideoConfig, setShowLiveVideoEditor, showLiveVideoEditor } =
     usePostLiveStore();
-  const { attachments } = usePostAttachmentStore((state) => state);
+  const { attachments } = usePostAttachmentStore();
   const disable = attachments.length > 0;
 
   return (

--- a/apps/web/src/components/Composer/ChooseThumbnail.tsx
+++ b/apps/web/src/components/Composer/ChooseThumbnail.tsx
@@ -22,7 +22,7 @@ const ChooseThumbnail = () => {
   const [thumbnails, setThumbnails] = useState<Thumbnail[]>([]);
   const [imageUploading, setImageUploading] = useState(false);
   const [selectedThumbnailIndex, setSelectedThumbnailIndex] = useState(-1);
-  const { attachments } = usePostAttachmentStore((state) => state);
+  const { attachments } = usePostAttachmentStore();
   const { setVideoThumbnail, videoThumbnail } = usePostVideoStore();
   const { file } = attachments[0];
 

--- a/apps/web/src/components/Composer/LinkPreviews.tsx
+++ b/apps/web/src/components/Composer/LinkPreviews.tsx
@@ -5,7 +5,7 @@ import { usePostStore } from "@/store/non-persisted/post/usePostStore";
 
 const LinkPreviews = () => {
   const { postContent, quotedPost } = usePostStore();
-  const { attachments } = usePostAttachmentStore((state) => state);
+  const { attachments } = usePostAttachmentStore();
   const urls = getURLs(postContent);
 
   if (!urls.length || attachments.length || quotedPost) {

--- a/apps/web/src/components/Composer/NewAttachments.tsx
+++ b/apps/web/src/components/Composer/NewAttachments.tsx
@@ -29,7 +29,7 @@ const NewAttachments = ({
   attachments = [],
   hideDelete = false
 }: NewAttachmentsProps) => {
-  const { setAttachments } = usePostAttachmentStore((state) => state);
+  const { setAttachments } = usePostAttachmentStore();
   const { setVideoDurationInSeconds } = usePostVideoStore();
   const videoRef = useRef<HTMLVideoElement>(null);
 

--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -79,7 +79,7 @@ const NewPublication = ({ className, post, feed }: NewPublicationProps) => {
 
   // Attachment store
   const { addAttachments, attachments, isUploading, setAttachments } =
-    usePostAttachmentStore((state) => state);
+    usePostAttachmentStore();
 
   // License store
   const { setLicense } = usePostLicenseStore();

--- a/apps/web/src/components/Post/Actions/Menu/Edit.tsx
+++ b/apps/web/src/components/Post/Actions/Menu/Edit.tsx
@@ -17,7 +17,7 @@ interface EditProps {
 const Edit = ({ post }: EditProps) => {
   const { setShowNewPostModal } = useNewPostModalStore();
   const { setPostContent, setEditingPost } = usePostStore();
-  const { setAttachments } = usePostAttachmentStore((state) => state);
+  const { setAttachments } = usePostAttachmentStore();
 
   const handleEdit = () => {
     const data = getPostData(post.metadata);

--- a/apps/web/src/components/Shared/GlobalModals.tsx
+++ b/apps/web/src/components/Shared/GlobalModals.tsx
@@ -27,7 +27,7 @@ const GlobalModals = () => {
   const { showNewPostModal, setShowNewPostModal } = useNewPostModalStore();
   const { editingPost, setEditingPost, setQuotedPost, setPostContent } =
     usePostStore();
-  const { setAttachments } = usePostAttachmentStore((state) => state);
+  const { setAttachments } = usePostAttachmentStore();
   const { authModalType, showAuthModal, setShowAuthModal } =
     useAuthModalStore();
   const {

--- a/apps/web/src/hooks/prosekit/usePaste.tsx
+++ b/apps/web/src/hooks/prosekit/usePaste.tsx
@@ -39,7 +39,7 @@ const definePasteDropExtension = (onPaste: (files: FileList) => void) => {
 };
 
 export const usePaste = (editor: Editor<EditorExtension>) => {
-  const { attachments } = usePostAttachmentStore((state) => state);
+  const { attachments } = usePostAttachmentStore();
   const { handleUploadAttachments } = useUploadAttachments();
 
   const handlePaste = useCallback(

--- a/apps/web/src/hooks/usePostMetadata.tsx
+++ b/apps/web/src/hooks/usePostMetadata.tsx
@@ -21,7 +21,7 @@ const usePostMetadata = () => {
   const { videoDurationInSeconds, videoThumbnail } = usePostVideoStore();
   const { audioPost } = usePostAudioStore();
   const { license } = usePostLicenseStore();
-  const { attachments } = usePostAttachmentStore((state) => state);
+  const { attachments } = usePostAttachmentStore();
   const { liveVideoConfig, showLiveVideoEditor } = usePostLiveStore();
 
   const formatAttachments = () =>

--- a/apps/web/src/hooks/useUploadAttachments.tsx
+++ b/apps/web/src/hooks/useUploadAttachments.tsx
@@ -12,7 +12,7 @@ const useUploadAttachments = () => {
     removeAttachments,
     setIsUploading,
     updateAttachments
-  } = usePostAttachmentStore((state) => state);
+  } = usePostAttachmentStore();
 
   const validateFileSize = (file: File): boolean => {
     const isImage = file.type.includes("image");

--- a/apps/web/src/store/non-persisted/post/usePostAttachmentStore.ts
+++ b/apps/web/src/store/non-persisted/post/usePostAttachmentStore.ts
@@ -1,5 +1,5 @@
 import type { NewAttachment } from "@hey/types/misc";
-import { create } from "zustand";
+import { createTrackedStore } from "@/store/createTrackedStore";
 
 interface State {
   addAttachments: (attachments: NewAttachment[]) => void;
@@ -11,7 +11,7 @@ interface State {
   updateAttachments: (attachments: NewAttachment[]) => void;
 }
 
-const store = create<State>((set) => ({
+const { useStore: usePostAttachmentStore } = createTrackedStore<State>((set) => ({
   addAttachments: (newAttachments) =>
     set((state) => {
       return { attachments: [...state.attachments, ...newAttachments] };
@@ -44,4 +44,4 @@ const store = create<State>((set) => ({
     })
 }));
 
-export const usePostAttachmentStore = store;
+export { usePostAttachmentStore };


### PR DESCRIPTION
## Summary
- refactor post attachment store to use `createTrackedStore`
- update components and hooks that read the store

## Testing
- `pnpm biome:check` *(fails: unknown keys in biome.json)*
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6859174600ac8330b26907e0dff6453b