### PR TITLE
refactor: memoize fetchMore callbacks

### DIFF
--- a/apps/web/src/components/Account/AccountFeed.tsx
+++ b/apps/web/src/components/Account/AccountFeed.tsx
@@ -7,6 +7,7 @@ import {
   PostType,
   usePostsQuery
 } from "@hey/indexer";
+import { useCallback } from "react";
 import SinglePost from "@/components/Post/SinglePost";
 import PostFeed from "@/components/Shared/Post/PostFeed";
 
@@ -81,13 +82,13 @@ const AccountFeed = ({ username, address, type }: AccountFeedProps) => {
   const pageInfo = data?.posts?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   return (
     <PostFeed

--- a/apps/web/src/components/Bookmarks/BookmarksFeed.tsx
+++ b/apps/web/src/components/Bookmarks/BookmarksFeed.tsx
@@ -5,6 +5,7 @@ import {
   type PostBookmarksRequest,
   usePostBookmarksQuery
 } from "@hey/indexer";
+import { useCallback } from "react";
 import SinglePost from "@/components/Post/SinglePost";
 import PostFeed from "@/components/Shared/Post/PostFeed";
 
@@ -26,13 +27,13 @@ const BookmarksFeed = ({ focus }: BookmarksFeedProps) => {
   const pageInfo = data?.postBookmarks?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
   return (
     <PostFeed
       emptyIcon={<BookmarkIcon className="size-8" />}

--- a/apps/web/src/components/Comment/CommentFeed.tsx
+++ b/apps/web/src/components/Comment/CommentFeed.tsx
@@ -8,6 +8,7 @@ import {
   ReferenceRelevancyFilter,
   usePostReferencesQuery
 } from "@hey/indexer";
+import { useCallback } from "react";
 import { useHiddenCommentFeedStore } from "@/components/Post";
 import SinglePost from "@/components/Post/SinglePost";
 import PostFeed from "@/components/Shared/Post/PostFeed";
@@ -39,13 +40,13 @@ const CommentFeed = ({ postId }: CommentFeedProps) => {
   const pageInfo = data?.postReferences?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const filteredComments = comments.filter(
     (comment) =>

--- a/apps/web/src/components/Comment/NoneRelevantFeed.tsx
+++ b/apps/web/src/components/Comment/NoneRelevantFeed.tsx
@@ -10,7 +10,7 @@ import {
   ReferenceRelevancyFilter,
   usePostReferencesQuery
 } from "@hey/indexer";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useHiddenCommentFeedStore } from "@/components/Post";
 import SinglePost from "@/components/Post/SinglePost";
 import PostFeed from "@/components/Shared/Post/PostFeed";
@@ -45,13 +45,13 @@ const NoneRelevantFeed = ({ postId }: NoneRelevantFeedProps) => {
   const hasMore = pageInfo?.next;
   const totalComments = comments?.length;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   if (totalComments === 0) {
     return null;

--- a/apps/web/src/components/Explore/ExploreFeed.tsx
+++ b/apps/web/src/components/Explore/ExploreFeed.tsx
@@ -5,6 +5,7 @@ import {
   type PostsExploreRequest,
   usePostsExploreQuery
 } from "@hey/indexer";
+import { useCallback } from "react";
 import SinglePost from "@/components/Post/SinglePost";
 import PostFeed from "@/components/Shared/Post/PostFeed";
 
@@ -28,13 +29,13 @@ const ExploreFeed = ({ focus }: ExploreFeedProps) => {
   const pageInfo = data?.mlPostsExplore?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const filteredPosts = (posts ?? []).filter(
     (post) =>

--- a/apps/web/src/components/Group/GroupFeed.tsx
+++ b/apps/web/src/components/Group/GroupFeed.tsx
@@ -1,5 +1,6 @@
 import { ChatBubbleBottomCenterIcon } from "@heroicons/react/24/outline";
 import { PageSize, type PostsRequest, usePostsQuery } from "@hey/indexer";
+import { useCallback } from "react";
 import SinglePost from "@/components/Post/SinglePost";
 import PostFeed from "@/components/Shared/Post/PostFeed";
 
@@ -22,13 +23,13 @@ const GroupFeed = ({ feed }: GroupFeedProps) => {
   const pageInfo = data?.posts?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const filteredPosts = (posts ?? []).filter(
     (post) =>

--- a/apps/web/src/components/Groups/List.tsx
+++ b/apps/web/src/components/Groups/List.tsx
@@ -6,6 +6,7 @@ import {
   PageSize,
   useGroupsQuery
 } from "@hey/indexer";
+import { useCallback } from "react";
 import { WindowVirtualizer } from "virtua";
 import SingleGroup from "@/components/Shared/Group/SingleGroup";
 import GroupListShimmer from "@/components/Shared/Shimmer/GroupListShimmer";
@@ -41,13 +42,13 @@ const List = ({ feedType }: ListProps) => {
   const pageInfo = data?.groups?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Home/ForYou.tsx
+++ b/apps/web/src/components/Home/ForYou.tsx
@@ -5,6 +5,7 @@ import {
   type PostsForYouRequest,
   usePostsForYouQuery
 } from "@hey/indexer";
+import { useCallback } from "react";
 import SinglePost from "@/components/Post/SinglePost";
 import PostFeed from "@/components/Shared/Post/PostFeed";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
@@ -26,13 +27,13 @@ const ForYou = () => {
   const pageInfo = data?.mlPostsForYou.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const filteredPosts = posts
     ?.map((item) => item.post)

--- a/apps/web/src/components/Home/Highlights.tsx
+++ b/apps/web/src/components/Home/Highlights.tsx
@@ -4,6 +4,7 @@ import {
   type TimelineHighlightsRequest,
   useTimelineHighlightsQuery
 } from "@hey/indexer";
+import { useCallback } from "react";
 import SinglePost from "@/components/Post/SinglePost";
 import PostFeed from "@/components/Shared/Post/PostFeed";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
@@ -24,13 +25,13 @@ const Highlights = () => {
   const pageInfo = data?.timelineHighlights.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const filteredPosts = (posts ?? []).filter(
     (post) =>

--- a/apps/web/src/components/Home/Timeline/index.tsx
+++ b/apps/web/src/components/Home/Timeline/index.tsx
@@ -4,7 +4,7 @@ import {
   type TimelineRequest,
   useTimelineQuery
 } from "@hey/indexer";
-import { memo } from "react";
+import { memo, useCallback } from "react";
 import SinglePost from "@/components/Post/SinglePost";
 import PostFeed from "@/components/Shared/Post/PostFeed";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
@@ -30,13 +30,13 @@ const Timeline = () => {
   const pageInfo = data?.timeline?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const filteredPosts = (feed ?? []).filter(
     (timelineItem) =>

--- a/apps/web/src/components/Notification/List.tsx
+++ b/apps/web/src/components/Notification/List.tsx
@@ -5,6 +5,7 @@ import {
   NotificationType,
   useNotificationsQuery
 } from "@hey/indexer";
+import { useCallback } from "react";
 import { WindowVirtualizer } from "virtua";
 import AccountActionExecutedNotification from "@/components/Notification/Type/AccountActionExecutedNotification";
 import CommentNotification from "@/components/Notification/Type/CommentNotification";
@@ -70,13 +71,13 @@ const List = ({ feedType }: ListProps) => {
   const pageInfo = data?.notifications?.pageInfo;
   const hasMore = !!pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Post/Quotes.tsx
+++ b/apps/web/src/components/Post/Quotes.tsx
@@ -6,6 +6,7 @@ import {
   PostReferenceType,
   usePostReferencesQuery
 } from "@hey/indexer";
+import { useCallback } from "react";
 import { WindowVirtualizer } from "virtua";
 import BackButton from "@/components/Shared/BackButton";
 import PostsShimmer from "@/components/Shared/Shimmer/PostsShimmer";
@@ -38,13 +39,13 @@ const Quotes = ({ post }: QuotesProps) => {
   const pageInfo = data?.postReferences?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Search/Accounts.tsx
+++ b/apps/web/src/components/Search/Accounts.tsx
@@ -5,6 +5,7 @@ import {
   PageSize,
   useAccountsQuery
 } from "@hey/indexer";
+import { useCallback } from "react";
 import { WindowVirtualizer } from "virtua";
 import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import SingleAccountsShimmer from "@/components/Shared/Shimmer/SingleAccountsShimmer";
@@ -31,13 +32,13 @@ const Accounts = ({ query }: AccountsProps) => {
   const pageInfo = data?.accounts?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Search/Posts.tsx
+++ b/apps/web/src/components/Search/Posts.tsx
@@ -1,5 +1,6 @@
 import { ChatBubbleBottomCenterIcon } from "@heroicons/react/24/outline";
 import { PageSize, type PostsRequest, usePostsQuery } from "@hey/indexer";
+import { useCallback } from "react";
 import SinglePost from "@/components/Post/SinglePost";
 import PostFeed from "@/components/Shared/Post/PostFeed";
 
@@ -21,13 +22,13 @@ const Posts = ({ query }: PostsProps) => {
   const pageInfo = data?.posts?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   return (
     <PostFeed

--- a/apps/web/src/components/Settings/Blocked/List.tsx
+++ b/apps/web/src/components/Settings/Blocked/List.tsx
@@ -4,6 +4,7 @@ import {
   PageSize,
   useAccountsBlockedQuery
 } from "@hey/indexer";
+import { useCallback } from "react";
 import { WindowVirtualizer } from "virtua";
 import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import Loader from "@/components/Shared/Loader";
@@ -26,13 +27,13 @@ const List = () => {
   const pageInfo = data?.accountsBlocked?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Settings/Manager/AccountManager/Management/List.tsx
+++ b/apps/web/src/components/Settings/Manager/AccountManager/Management/List.tsx
@@ -7,7 +7,7 @@ import {
   useHideManagedAccountMutation,
   useUnhideManagedAccountMutation
 } from "@hey/indexer";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { WindowVirtualizer } from "virtua";
 import { useAccount } from "wagmi";
@@ -54,7 +54,7 @@ const List = ({ managed = false }: ListProps) => {
   const pageInfo = data?.accountsAvailable?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: {
@@ -66,7 +66,13 @@ const List = ({ managed = false }: ListProps) => {
         }
       });
     }
-  };
+  }, [
+    fetchMore,
+    hasMore,
+    pageInfo?.next,
+    accountsAvailableRequest,
+    lastLoggedInAccountRequest
+  ]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Settings/Manager/AccountManager/Managers/List.tsx
+++ b/apps/web/src/components/Settings/Manager/AccountManager/Managers/List.tsx
@@ -9,7 +9,7 @@ import {
   useRemoveAccountManagerMutation
 } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { WindowVirtualizer } from "virtua";
 import WalletAccount from "@/components/Shared/Account/WalletAccount";
@@ -81,13 +81,13 @@ const List = () => {
   const pageInfo = data?.accountManagers?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Settings/Sessions/List.tsx
+++ b/apps/web/src/components/Settings/Sessions/List.tsx
@@ -6,7 +6,7 @@ import {
   useRevokeAuthenticationMutation
 } from "@hey/indexer";
 import type { ApolloClientError } from "@hey/types/errors";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { WindowVirtualizer } from "virtua";
 import Loader from "@/components/Shared/Loader";
@@ -62,13 +62,13 @@ const List = () => {
   const pageInfo = data?.authenticatedSessions?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Shared/Modal/Followers.tsx
+++ b/apps/web/src/components/Shared/Modal/Followers.tsx
@@ -2,6 +2,7 @@ import { UsersIcon } from "@heroicons/react/24/outline";
 import type { FollowersRequest } from "@hey/indexer";
 import { PageSize, useFollowersQuery } from "@hey/indexer";
 import { motion } from "motion/react";
+import { useCallback } from "react";
 import { Virtualizer } from "virtua";
 import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
@@ -33,13 +34,13 @@ const Followers = ({ username, address }: FollowersProps) => {
   const pageInfo = data?.followers?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Shared/Modal/FollowersYouKnow.tsx
+++ b/apps/web/src/components/Shared/Modal/FollowersYouKnow.tsx
@@ -4,6 +4,7 @@ import {
   useFollowersYouKnowQuery
 } from "@hey/indexer";
 import { motion } from "motion/react";
+import { useCallback } from "react";
 import { Virtualizer } from "virtua";
 import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
@@ -35,13 +36,13 @@ const FollowersYouKnow = ({ username, address }: FollowersYouKnowProps) => {
   const pageInfo = data?.followersYouKnow?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Shared/Modal/Following.tsx
+++ b/apps/web/src/components/Shared/Modal/Following.tsx
@@ -2,6 +2,7 @@ import { UsersIcon } from "@heroicons/react/24/outline";
 import type { FollowingRequest } from "@hey/indexer";
 import { PageSize, useFollowingQuery } from "@hey/indexer";
 import { motion } from "motion/react";
+import { useCallback } from "react";
 import { Virtualizer } from "virtua";
 import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
@@ -33,13 +34,13 @@ const Following = ({ username, address }: FollowingProps) => {
   const pageInfo = data?.following?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Shared/Modal/Likes.tsx
+++ b/apps/web/src/components/Shared/Modal/Likes.tsx
@@ -5,6 +5,7 @@ import {
   usePostReactionsQuery
 } from "@hey/indexer";
 import { motion } from "motion/react";
+import { useCallback } from "react";
 import { Virtualizer } from "virtua";
 import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
@@ -35,13 +36,13 @@ const Likes = ({ postId }: LikesProps) => {
   const pageInfo = data?.postReactions?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Shared/Modal/Members/index.tsx
+++ b/apps/web/src/components/Shared/Modal/Members/index.tsx
@@ -6,6 +6,7 @@ import {
   useGroupMembersQuery
 } from "@hey/indexer";
 import { motion } from "motion/react";
+import { useCallback } from "react";
 import { Virtualizer } from "virtua";
 import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
@@ -36,13 +37,13 @@ const Members = ({ group }: MembersProps) => {
   const pageInfo = data?.groupMembers?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Shared/Modal/PostExecutors.tsx
+++ b/apps/web/src/components/Shared/Modal/PostExecutors.tsx
@@ -5,6 +5,7 @@ import {
   type WhoExecutedActionOnPostRequest
 } from "@hey/indexer";
 import { motion } from "motion/react";
+import { useCallback } from "react";
 import { Virtualizer } from "virtua";
 import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
@@ -36,13 +37,13 @@ const PostExecutors = ({ postId, filter }: PostExecutorsProps) => {
   const pageInfo = data?.whoExecutedActionOnPost?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 

--- a/apps/web/src/components/Shared/Modal/Reposts.tsx
+++ b/apps/web/src/components/Shared/Modal/Reposts.tsx
@@ -6,6 +6,7 @@ import {
   type WhoReferencedPostRequest
 } from "@hey/indexer";
 import { motion } from "motion/react";
+import { useCallback } from "react";
 import { Virtualizer } from "virtua";
 import SingleAccount from "@/components/Shared/Account/SingleAccount";
 import AccountListShimmer from "@/components/Shared/Shimmer/AccountListShimmer";
@@ -37,13 +38,13 @@ const Reposts = ({ postId }: RepostsProps) => {
   const pageInfo = data?.whoReferencedPost?.pageInfo;
   const hasMore = pageInfo?.next;
 
-  const handleEndReached = async () => {
+  const handleEndReached = useCallback(async () => {
     if (hasMore) {
       await fetchMore({
         variables: { request: { ...request, cursor: pageInfo?.next } }
       });
     }
-  };
+  }, [fetchMore, hasMore, pageInfo?.next, request]);
 
   const loadMoreRef = useLoadMoreOnIntersect(handleEndReached);
 


### PR DESCRIPTION
## Summary
- wrap fetchMore handlers with `useCallback`
- tidy imports in manager list components

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685969c4e4208330bd05c73f2dbeac1b