### PR TITLE
feat(web): memoize composer modules

### DIFF
--- a/apps/web/src/components/Composer/Actions/Attachment.tsx
+++ b/apps/web/src/components/Composer/Actions/Attachment.tsx
@@ -11,7 +11,7 @@ import {
 } from "@lens-protocol/metadata";
 import { useClickAway } from "@uidotdev/usehooks";
 import type { ChangeEvent, JSX, MutableRefObject } from "react";
-import { useId, useState } from "react";
+import { memo, useId, useState } from "react";
 import { toast } from "sonner";
 import MenuTransition from "@/components/Shared/MenuTransition";
 import { Spinner, Tooltip } from "@/components/Shared/UI";
@@ -155,4 +155,4 @@ const Attachment = () => {
   );
 };
 
-export default Attachment;
+export default memo(Attachment);

--- a/apps/web/src/components/Composer/ChooseThumbnail.tsx
+++ b/apps/web/src/components/Composer/ChooseThumbnail.tsx
@@ -1,6 +1,6 @@
 import { CheckCircleIcon, PhotoIcon } from "@heroicons/react/24/outline";
 import type { ChangeEvent } from "react";
-import { useEffect, useId, useState } from "react";
+import { memo, useEffect, useId, useState } from "react";
 import { toast } from "sonner";
 import ThumbnailsShimmer from "@/components/Shared/Shimmer/ThumbnailsShimmer";
 import { Spinner } from "@/components/Shared/UI";
@@ -186,4 +186,4 @@ const ChooseThumbnail = () => {
   );
 };
 
-export default ChooseThumbnail;
+export default memo(ChooseThumbnail);

--- a/apps/web/src/components/Composer/LinkPreviews.tsx
+++ b/apps/web/src/components/Composer/LinkPreviews.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import Oembed from "@/components/Shared/Post/Oembed";
 import getURLs from "@/helpers/getURLs";
 import { usePostAttachmentStore } from "@/store/non-persisted/post/usePostAttachmentStore";
@@ -19,4 +20,4 @@ const LinkPreviews = () => {
   );
 };
 
-export default LinkPreviews;
+export default memo(LinkPreviews);

--- a/apps/web/src/components/Composer/NewAttachments.tsx
+++ b/apps/web/src/components/Composer/NewAttachments.tsx
@@ -1,7 +1,7 @@
 import { XMarkIcon } from "@heroicons/react/24/solid";
 import { MAX_IMAGE_UPLOAD } from "@hey/data/constants";
 import type { NewAttachment } from "@hey/types/misc";
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import ChooseThumbnail from "@/components/Composer/ChooseThumbnail";
 import Audio from "@/components/Shared/Audio";
 import { Image } from "@/components/Shared/UI";
@@ -132,4 +132,4 @@ const NewAttachments = ({
   ) : null;
 };
 
-export default NewAttachments;
+export default memo(NewAttachments);


### PR DESCRIPTION
## Summary
- wrap attachment actions with React.memo
- prevent unnecessary re-renders for new attachments
- memoize link previews and thumbnail chooser

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68596a0383248330874caf891ebbd65f