### PR TITLE
fix: remove period in copyright

### DIFF
--- a/apps/web/src/components/Pages/Copyright.tsx
+++ b/apps/web/src/components/Pages/Copyright.tsx
@@ -25,7 +25,7 @@ const Copyright = () => {
               <H4 className="mb-5">Notification of Copyright Infringement</H4>
               <div className="space-y-5">
                 <p className="leading-7">
-                  Hey. ("Hey.xyz") respects the intellectual property rights of
+                  Hey ("Hey.xyz") respects the intellectual property rights of
                   others and expects its users to do the same.
                 </p>
                 <p className="leading-7">


### PR DESCRIPTION
## Summary
- remove stray period in copyright notice

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685cdcb235548330a9f1bfdb6f39dae8