### PR TITLE
fix: correct comment typos

### DIFF
--- a/apps/web/src/components/Pages/Copyright.tsx
+++ b/apps/web/src/components/Pages/Copyright.tsx
@@ -21,7 +21,7 @@ const Copyright = () => {
         <div className="flex justify-center">
           <div className="relative mx-auto rounded-lg">
             <div className="!p-8 max-w-none text-gray-500 dark:text-gray-200">
-              {/* Notification of Copyright Infringement beings */}
+              {/* Notification of Copyright Infringement begins */}
               <H4 className="mb-5">Notification of Copyright Infringement</H4>
               <div className="space-y-5">
                 <p className="leading-7">
@@ -63,7 +63,7 @@ const Copyright = () => {
                 </p>
               </div>
               {/* Notification of Copyright Infringement ends */}
-              {/* DMCA Notice of Alleged Infringement ("Notice") beings */}
+              {/* DMCA Notice of Alleged Infringement ("Notice") begins */}
               <H4 className="mt-8 mb-5">
                 DMCA Notice of Alleged Infringement ("Notice")
               </H4>

--- a/apps/web/src/components/Pages/Guidelines.tsx
+++ b/apps/web/src/components/Pages/Guidelines.tsx
@@ -22,7 +22,7 @@ const Guidelines = () => {
                   your Account.
                 </p>
               </div>
-              {/* Safety beings */}
+              {/* Safety begins */}
               <H4 className="mt-8 mb-5">Safety</H4>
               <div className="space-y-5">
                 <p className="leading-7">
@@ -40,7 +40,7 @@ const Guidelines = () => {
                 </ul>
               </div>
               {/* Safety ends */}
-              {/* Nudity beings */}
+              {/* Nudity begins */}
               <H4 className="mt-8 mb-5">Nudity</H4>
               <div className="space-y-5">
                 <p className="leading-7">
@@ -57,7 +57,7 @@ const Guidelines = () => {
                 </p>
               </div>
               {/* Nudity ends */}
-              {/* Spam beings */}
+              {/* Spam begins */}
               <H4 className="mt-8 mb-5">Spam</H4>
               <div className="space-y-5">
                 <p className="leading-7">
@@ -77,7 +77,7 @@ const Guidelines = () => {
                 </p>
               </div>
               {/* Spam ends */}
-              {/* Impersonation beings */}
+              {/* Impersonation begins */}
               <H4 className="mt-8 mb-5">Impersonation</H4>
               <div className="space-y-5">
                 <p className="leading-7">
@@ -107,14 +107,14 @@ const Guidelines = () => {
                 </p>
               </div>
               {/* Impersonation ends */}
-              {/* Copyright and Trademarks beings */}
+              {/* Copyright and Trademarks begins */}
               <H4 className="mt-8 mb-5">Copyright and Trademarks</H4>
               <p className="leading-7">
                 You are not allowed to violate any intellectual property rights,
                 including copyright and trademark, of others.
               </p>
               {/* Copyright and Trademarks ends */}
-              {/* Feedback beings */}
+              {/* Feedback begins */}
               <H4 className="mt-8 mb-5">Feedback</H4>
               <p className="linkify leading-7">
                 If you have any feedback on these rules or if you have any

--- a/apps/web/src/components/Pages/Privacy.tsx
+++ b/apps/web/src/components/Pages/Privacy.tsx
@@ -21,7 +21,7 @@ const Privacy = () => {
         <div className="flex justify-center">
           <div className="relative mx-auto rounded-lg">
             <div className="!p-8 max-w-none text-gray-500 dark:text-gray-200">
-              {/* 1. Overview beings */}
+              {/* 1. Overview begins */}
               <H4 className="mb-5">1. Overview</H4>
               <div className="space-y-5">
                 <p className="leading-7">
@@ -55,7 +55,7 @@ const Privacy = () => {
                 </p>
               </div>
               {/* 1. Overview ends */}
-              {/* 2. Information Collection beings */}
+              {/* 2. Information Collection begins */}
               <H4 className="mt-8 mb-5">2. Information Collection</H4>
               <div className="space-y-5">
                 <p className="leading-7">

--- a/apps/web/src/components/Pages/Terms.tsx
+++ b/apps/web/src/components/Pages/Terms.tsx
@@ -21,7 +21,7 @@ const Terms = () => {
         <div className="flex justify-center">
           <div className="relative mx-auto rounded-lg">
             <div className="!p-8 max-w-none text-gray-500 dark:text-gray-200">
-              {/* 1. Overview beings */}
+              {/* 1. Overview begins */}
               <H4 className="mb-5">1. Overview</H4>
               <div className="space-y-5">
                 <p className="leading-7">
@@ -58,7 +58,7 @@ const Terms = () => {
                 </p>
               </div>
               {/* 1. Overview ends */}
-              {/* 2. General Conditions beings */}
+              {/* 2. General Conditions begins */}
               <H4 className="mt-8 mb-5">2. General Conditions</H4>
               <p className="leading-7">
                 You may not use our Site for any illegal or unauthorised purpose


### PR DESCRIPTION
## Summary
- fix spelling of comment tags across page components

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685cdcbbcc4c8330bf355dd0ad152419