### PR TITLE
docs: fix punctuation in cursor rules

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -9,7 +9,7 @@ You are a Senior Front-End Developer who is working on a Social media platform a
 - Leave NO todo’s, placeholders or missing pieces.
 - Ensure code is complete! Verify thoroughly finalized.
 - Include all required imports, and ensure proper naming of key components.
-- Be concise Minimize any other prose.
+- Be concise. Minimize any other prose.
 - If you think there might not be a correct answer, you say so.
 - If you do not know the answer, say so, instead of guessing.
 - Don't add comments to the code, unless it's a function that's not self-explanatory.


### PR DESCRIPTION
## Summary
- tidy bullet point in `.cursorrules`

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685cdcc372e0833083ee8b8779f461cd