### PR TITLE
feat: add jwt payload interfaces

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,6 +40,7 @@
     "@hey/config": "workspace:*",
     "@types/node": "^24.0.4",
     "prisma": "^6.10.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@hey/types": "workspace:*"
   }
 }

--- a/apps/api/src/context/authContext.ts
+++ b/apps/api/src/context/authContext.ts
@@ -1,9 +1,10 @@
 import parseJwt from "@hey/helpers/parseJwt";
+import type { JwtPayload } from "@hey/types/jwt";
 import type { Context, Next } from "hono";
 
 const authContext = async (ctx: Context, next: Next) => {
   const token = ctx.req.raw.headers.get("X-Access-Token");
-  const payload = parseJwt(token as string);
+  const payload: JwtPayload = parseJwt(token as string);
 
   if (!payload.act.sub) {
     ctx.set("account", null);

--- a/apps/web/src/helpers/tokenManager.ts
+++ b/apps/web/src/helpers/tokenManager.ts
@@ -1,6 +1,7 @@
 import parseJwt from "@hey/helpers/parseJwt";
 import { RefreshDocument, type RefreshMutation } from "@hey/indexer";
 import apolloClient from "@hey/indexer/apollo/client";
+import type { JwtPayload } from "@hey/types/jwt";
 import { signIn, signOut } from "@/store/persisted/useAuthStore";
 
 let refreshPromise: Promise<string> | null = null;
@@ -65,7 +66,7 @@ export const isTokenExpiringSoon = (accessToken: string | null): boolean => {
     return false;
   }
 
-  const tokenData = parseJwt(accessToken);
+  const tokenData: JwtPayload = parseJwt(accessToken);
   const bufferInMinutes = 5;
   return (
     !!tokenData.exp &&

--- a/packages/helpers/parseJwt.ts
+++ b/packages/helpers/parseJwt.ts
@@ -1,15 +1,10 @@
+import type { JwtPayload } from "@hey/types/jwt";
+
 const decoded = (str: string): string => atob(str);
 
-const parseJwt = (
-  token: string
-): {
-  sub: string;
-  exp: number;
-  sid: string;
-  act: { sub: string };
-} => {
+const parseJwt = (token: string): JwtPayload => {
   try {
-    return JSON.parse(decoded(token.split(".")[1]));
+    return JSON.parse(decoded(token.split(".")[1])) as JwtPayload;
   } catch {
     return {
       act: { sub: "" },

--- a/packages/types/jwt.d.ts
+++ b/packages/types/jwt.d.ts
@@ -1,0 +1,10 @@
+export interface JwtActClaim {
+  sub: string;
+}
+
+export interface JwtPayload {
+  sub: string;
+  exp: number;
+  sid: string;
+  act: JwtActClaim;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@hey/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@hey/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       '@types/node':
         specifier: ^24.0.4
         version: 24.0.4


### PR DESCRIPTION
## Summary
- describe parsed JWT payloads in new interfaces
- return the interface from parseJwt
- use the parsed payload type in authContext and tokenManager
- add @hey/types to API dev deps

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685cfce3069c8330aadd3b796ae9120d