### PR TITLE
feat: add variants for EmptyState

### DIFF
--- a/apps/web/src/components/Shared/UI/EmptyState.tsx
+++ b/apps/web/src/components/Shared/UI/EmptyState.tsx
@@ -1,6 +1,6 @@
+import { cva } from "class-variance-authority";
 import { memo, type ReactNode } from "react";
 import { Card } from "@/components/Shared/UI";
-import cn from "@/helpers/cn";
 
 interface EmptyStateProps {
   hideCard?: boolean;
@@ -9,6 +9,16 @@ interface EmptyStateProps {
   className?: string;
 }
 
+const emptyStateVariants = cva("", {
+  defaultVariants: { hideCard: false },
+  variants: {
+    hideCard: {
+      false: "",
+      true: "!bg-transparent !shadow-none !border-0"
+    }
+  }
+});
+
 const EmptyState = ({
   hideCard = false,
   icon,
@@ -16,12 +26,7 @@ const EmptyState = ({
   className = ""
 }: EmptyStateProps) => {
   return (
-    <Card
-      className={cn(
-        { "!bg-transparent !shadow-none !border-0": hideCard },
-        className
-      )}
-    >
+    <Card className={emptyStateVariants({ className, hideCard })}>
       <div className="grid justify-items-center space-y-2 p-5">
         <div>{icon}</div>
         <div>{message}</div>


### PR DESCRIPTION
## Summary
- define `emptyStateVariants` with class-variance-authority
- use the new variant to simplify the card wrapper

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6860d746d6e483308141b485ab30ac97