### PR TITLE
fix: assign unique key to settings shortcut

### DIFF
--- a/apps/web/src/helpers/shortcuts.ts
+++ b/apps/web/src/helpers/shortcuts.ts
@@ -9,7 +9,7 @@ const KeyboardShortcuts = {
   GoToHome: { key: "g+h", name: "Go to Home" },
   GoToNotifications: { key: "g+n", name: "Go to Notifications" },
   GoToSearch: { key: "g+s", name: "Go to Search" },
-  GoToSettings: { key: "g+s", name: "Go to Settings" },
+  GoToSettings: { key: "g+t", name: "Go to Settings" },
   ThisModal: { key: "?", name: "Shortcut help" }
 };
 


### PR DESCRIPTION
## Summary
- assign a unique keyboard shortcut for settings

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6860d7875a9883308b35b4bda860556e