### PR TITLE
feat(api): add generic lensPg types

### DIFF
--- a/apps/api/src/routes/jumper/getStats.ts
+++ b/apps/api/src/routes/jumper/getStats.ts
@@ -24,7 +24,7 @@ const getStats = async (ctx: Context) => {
       [address.replace("0x", "\\x")]
     )) as Array<{ address: Buffer }>;
 
-    const result = await lensPg.query(
+    const result = await lensPg.query<Array<{ type: string; count: string }>>(
       `
         SELECT 'tip' AS type, COUNT(*) AS count
         FROM post.action_executed

--- a/apps/api/src/utils/lensPg.ts
+++ b/apps/api/src/utils/lensPg.ts
@@ -42,8 +42,9 @@ class Database {
     connectionParameters: IConnectionParameters
   ): InitializeDbResult {
     const pgp = pgPromise({
-      error: (error: any) => {
-        const errorMessage = error.message || error;
+      error: (error: unknown) => {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
         console.error(`LENS POSTGRES ERROR WITH TRACE: ${errorMessage}`);
       }
     });
@@ -54,18 +55,18 @@ class Database {
     };
   }
 
-  public multi(
+  public multi<T = unknown>(
     query: DatabaseQuery,
     params: DatabaseParams = null
-  ): Promise<any[][]> {
-    return this._readDb.multi(query, params);
+  ): Promise<T[][]> {
+    return this._readDb.multi<T>(query, params);
   }
 
-  public query(
+  public query<T = unknown>(
     query: DatabaseQuery,
     params: DatabaseParams = null
-  ): Promise<any[]> {
-    return this._readDb.query(query, params);
+  ): Promise<T> {
+    return this._readDb.query<T>(query, params);
   }
 }
 


### PR DESCRIPTION
## Summary
- handle pg error type properly
- make database query helpers generic
- type query call in `getStats`

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6860e1c66b7083309213ade78aa80626