### PR TITLE
feat: add reusable page header

### DIFF
--- a/apps/web/src/components/Pages/Copyright.tsx
+++ b/apps/web/src/components/Pages/Copyright.tsx
@@ -1,22 +1,14 @@
 import { Link } from "react-router";
 import PageLayout from "@/components/Shared/PageLayout";
-import { H2, H4 } from "@/components/Shared/UI";
+import { H4 } from "@/components/Shared/UI";
+import PageHeader from "@/components/Pages/PageHeader";
 
 const Copyright = () => {
   const updatedAt = "October 22, 2024";
 
   return (
     <PageLayout title="Copyright Policy">
-      <div className="flex h-48 w-full items-center justify-center rounded-none bg-gray-400 md:rounded-xl">
-        <div className="relative text-center">
-          <H2 className="text-white">Copyright Policy</H2>
-          <div className="mt-4 flex justify-center">
-            <div className="rounded-md bg-gray-800 px-2 py-0.5 text-white text-xs">
-              Updated {updatedAt}
-            </div>
-          </div>
-        </div>
-      </div>
+      <PageHeader title="Copyright Policy" updatedAt={updatedAt} />
       <div className="relative">
         <div className="flex justify-center">
           <div className="relative mx-auto rounded-lg">

--- a/apps/web/src/components/Pages/Guidelines.tsx
+++ b/apps/web/src/components/Pages/Guidelines.tsx
@@ -1,15 +1,12 @@
 import { Link } from "react-router";
 import PageLayout from "@/components/Shared/PageLayout";
-import { H2, H4 } from "@/components/Shared/UI";
+import { H4 } from "@/components/Shared/UI";
+import PageHeader from "@/components/Pages/PageHeader";
 
 const Guidelines = () => {
   return (
     <PageLayout title="Community Guidelines">
-      <div className="flex h-48 w-full items-center justify-center rounded-none bg-gray-400 md:rounded-xl">
-        <div className="relative text-center">
-          <H2 className="text-white">Community Guidelines</H2>
-        </div>
-      </div>
+      <PageHeader title="Community Guidelines" />
       <div className="relative">
         <div className="flex justify-center">
           <div className="relative mx-auto rounded-lg">

--- a/apps/web/src/components/Pages/PageHeader.tsx
+++ b/apps/web/src/components/Pages/PageHeader.tsx
@@ -1,0 +1,23 @@
+import { H2 } from "@/components/Shared/UI";
+
+interface PageHeaderProps {
+  title: string;
+  updatedAt?: string;
+}
+
+const PageHeader = ({ title, updatedAt }: PageHeaderProps) => (
+  <div className="flex h-48 w-full items-center justify-center rounded-none bg-gray-400 md:rounded-xl">
+    <div className="relative text-center">
+      <H2 className="text-white">{title}</H2>
+      {updatedAt ? (
+        <div className="mt-4 flex justify-center">
+          <div className="rounded-md bg-gray-800 px-2 py-0.5 text-xs text-white">
+            Updated {updatedAt}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  </div>
+);
+
+export default PageHeader;

--- a/apps/web/src/components/Pages/Privacy.tsx
+++ b/apps/web/src/components/Pages/Privacy.tsx
@@ -1,22 +1,14 @@
 import { Link } from "react-router";
 import PageLayout from "@/components/Shared/PageLayout";
-import { H2, H4 } from "@/components/Shared/UI";
+import { H4 } from "@/components/Shared/UI";
+import PageHeader from "@/components/Pages/PageHeader";
 
 const Privacy = () => {
   const updatedAt = "October 30, 2023";
 
   return (
     <PageLayout title="Privacy Policy">
-      <div className="flex h-48 w-full items-center justify-center rounded-none bg-gray-400 md:rounded-xl">
-        <div className="relative text-center">
-          <H2 className="text-white">Privacy Policy</H2>
-          <div className="mt-4 flex justify-center">
-            <div className="rounded-md bg-gray-800 px-2 py-0.5 text-white text-xs">
-              Updated {updatedAt}
-            </div>
-          </div>
-        </div>
-      </div>
+      <PageHeader title="Privacy Policy" updatedAt={updatedAt} />
       <div className="relative">
         <div className="flex justify-center">
           <div className="relative mx-auto rounded-lg">

--- a/apps/web/src/components/Pages/Terms.tsx
+++ b/apps/web/src/components/Pages/Terms.tsx
@@ -1,22 +1,14 @@
 import { Link } from "react-router";
 import PageLayout from "@/components/Shared/PageLayout";
-import { H2, H4 } from "@/components/Shared/UI";
+import { H4 } from "@/components/Shared/UI";
+import PageHeader from "@/components/Pages/PageHeader";
 
 const Terms = () => {
   const updatedAt = "March 21, 2025";
 
   return (
     <PageLayout title="Terms & Conditions">
-      <div className="flex h-48 w-full items-center justify-center rounded-none bg-gray-400 md:rounded-xl">
-        <div className="relative text-center">
-          <H2 className="text-white">Terms & Conditions</H2>
-          <div className="mt-4 flex justify-center">
-            <div className="rounded-md bg-gray-800 px-2 py-0.5 text-white text-xs">
-              Updated {updatedAt}
-            </div>
-          </div>
-        </div>
-      </div>
+      <PageHeader title="Terms & Conditions" updatedAt={updatedAt} />
       <div className="relative">
         <div className="flex justify-center">
           <div className="relative mx-auto rounded-lg">


### PR DESCRIPTION
## Summary
- create `PageHeader` component for standard page headers
- use `PageHeader` in privacy, terms, guidelines, and copyright pages

## Testing
- `pnpm biome:check` *(fails: command not found)*
- `pnpm typecheck` *(fails: command not found)*
- `pnpm build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e980b94c83308b6fd1c26e5db6e0