### PR TITLE
feat: add group selector to composer

### DIFF
--- a/apps/web/src/components/Composer/GroupSelector.tsx
+++ b/apps/web/src/components/Composer/GroupSelector.tsx
@@ -1,0 +1,57 @@
+import getAvatar from "@hey/helpers/getAvatar";
+import {
+  type GroupFragment,
+  GroupsOrderBy,
+  type GroupsRequest,
+  PageSize,
+  useGroupsQuery
+} from "@hey/indexer";
+import { useMemo } from "react";
+import { Select } from "@/components/Shared/UI";
+import { useAccountStore } from "@/store/persisted/useAccountStore";
+
+interface GroupSelectorProps {
+  selected?: string;
+  onChange: (groupFeed: string) => void;
+}
+
+const GroupSelector = ({ selected, onChange }: GroupSelectorProps) => {
+  const { currentAccount } = useAccountStore();
+
+  const request: GroupsRequest = {
+    filter: { member: currentAccount?.address },
+    orderBy: GroupsOrderBy.LatestFirst,
+    pageSize: PageSize.Fifty
+  };
+
+  const { data } = useGroupsQuery({
+    skip: !currentAccount,
+    variables: { request }
+  });
+
+  const options = useMemo(() => {
+    const groups = data?.groups?.items ?? [];
+    return groups.map((group: GroupFragment) => ({
+      icon: getAvatar(group),
+      label: group.metadata?.name ?? group.address,
+      selected: group.feed?.address === selected,
+      value: group.feed?.address ?? ""
+    }));
+  }, [data?.groups?.items, selected]);
+
+  if (!options.length) {
+    return null;
+  }
+
+  return (
+    <Select
+      className="w-full"
+      iconClassName="size-5 rounded-md"
+      onChange={(value) => onChange(value as string)}
+      options={options as any}
+      showSearch
+    />
+  );
+};
+
+export default GroupSelector;

--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/store/non-persisted/post/usePostVideoStore";
 import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { Editor, useEditorContext, withEditorContext } from "./Editor";
+import GroupSelector from "./GroupSelector";
 import LinkPreviews from "./LinkPreviews";
 
 interface NewPublicationProps {
@@ -95,6 +96,7 @@ const NewPublication = ({ className, post, feed }: NewPublicationProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showEmojiPicker, setShowEmojiPicker] = useState<boolean>(false);
   const [postContentError, setPostContentError] = useState("");
+  const [selectedFeed, setSelectedFeed] = useState<string>(feed || "");
 
   const editor = useEditorContext();
   const getMetadata = usePostMetadata();
@@ -118,6 +120,7 @@ const NewPublication = ({ className, post, feed }: NewPublicationProps) => {
     setAudioPost(DEFAULT_AUDIO_POST);
     setLicense(null);
     resetCollectSettings();
+    setSelectedFeed(feed || "");
     setShowNewPostModal(false);
   };
 
@@ -140,6 +143,10 @@ const NewPublication = ({ className, post, feed }: NewPublicationProps) => {
     onCompleted,
     onError
   });
+
+  useEffect(() => {
+    setSelectedFeed(feed || "");
+  }, [feed]);
 
   useEffect(() => {
     setPostContentError("");
@@ -215,7 +222,7 @@ const NewPublication = ({ className, post, feed }: NewPublicationProps) => {
         variables: {
           request: {
             contentUri,
-            ...(feed && { feed }),
+            ...((feed || selectedFeed) && { feed: feed || selectedFeed }),
             ...(isComment && { commentOn: { post: post?.id } }),
             ...(isQuote && { quoteOf: { post: quotedPost?.id } }),
             ...(collectAction.enabled && {
@@ -248,6 +255,11 @@ const NewPublication = ({ className, post, feed }: NewPublicationProps) => {
 
   return (
     <Card className={className} onClick={() => setShowEmojiPicker(false)}>
+      {!feed && !isComment ? (
+        <div className="px-5 pt-5">
+          <GroupSelector onChange={setSelectedFeed} selected={selectedFeed} />
+        </div>
+      ) : null}
       <Editor isComment={isComment} />
       {postContentError ? (
         <H6 className="mt-1 px-5 pb-3 text-red-500">{postContentError}</H6>


### PR DESCRIPTION
## Summary
- allow posting to selected group in composer
- create `GroupSelector` component for fetching groups
- show dropdown when posting a new top-level post

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6864101f83048330858cc18632002721