### PR TITLE
feat: add shared logger utility

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "@hono/node-server";
 import "dotenv/config";
 import { Status } from "@hey/data/enums";
+import logger from "@hey/helpers/logger";
 import { Hono } from "hono";
 import authContext from "./context/authContext";
 import cors from "./middlewares/cors";
@@ -40,5 +41,5 @@ app.notFound((ctx) =>
 );
 
 serve({ fetch: app.fetch, port: 4784 }, (info) => {
-  console.info(`Server running on port ${info.port}`);
+  logger.info(`Server running on port ${info.port}`);
 });

--- a/apps/api/src/utils/lensPg.ts
+++ b/apps/api/src/utils/lensPg.ts
@@ -1,3 +1,4 @@
+import logger from "@hey/helpers/logger";
 import dotenv from "dotenv";
 import type { IDatabase, IFormatting, IHelpers, IMain } from "pg-promise";
 import pgPromise from "pg-promise";
@@ -45,7 +46,7 @@ class Database {
       error: (error: unknown) => {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
-        console.error(`LENS POSTGRES ERROR WITH TRACE: ${errorMessage}`);
+        logger.error(`LENS POSTGRES ERROR WITH TRACE: ${errorMessage}`);
       }
     });
 

--- a/apps/api/src/utils/redis.ts
+++ b/apps/api/src/utils/redis.ts
@@ -1,35 +1,35 @@
+import logger from "@hey/helpers/logger";
 import dotenv from "dotenv";
 import type { RedisClientType } from "redis";
 import { createClient } from "redis";
 
 dotenv.config({ override: true });
 
-const noRedisError = () =>
-  console.error("[Redis] Redis client not initialized");
+const noRedisError = () => logger.error("[Redis] Redis client not initialized");
 
 let redisClient: null | RedisClientType = null;
 
 if (process.env.REDIS_URL) {
   redisClient = createClient({ url: process.env.REDIS_URL });
 
-  redisClient.on("connect", () => console.info("[Redis] Redis connect"));
-  redisClient.on("ready", () => console.info("[Redis] Redis ready"));
+  redisClient.on("connect", () => logger.info("[Redis] Redis connect"));
+  redisClient.on("ready", () => logger.info("[Redis] Redis ready"));
   redisClient.on("reconnecting", (err) =>
-    console.error("[Redis] Redis reconnecting", err)
+    logger.error("[Redis] Redis reconnecting", err)
   );
-  redisClient.on("error", (err) => console.error("[Redis] Redis error", err));
-  redisClient.on("end", (err) => console.error("[Redis] Redis end", err));
+  redisClient.on("error", (err) => logger.error("[Redis] Redis error", err));
+  redisClient.on("end", (err) => logger.error("[Redis] Redis end", err));
 
   const connectRedis = async () => {
-    console.info("[Redis] Connecting to Redis");
+    logger.info("[Redis] Connecting to Redis");
     await redisClient?.connect();
   };
 
   connectRedis().catch((error) =>
-    console.error("[Redis] Connection error", error)
+    logger.error("[Redis] Connection error", error)
   );
 } else {
-  console.info("[Redis] REDIS_URL not set");
+  logger.info("[Redis] REDIS_URL not set");
 }
 
 const randomNumber = (min: number, max: number): number => {

--- a/packages/helpers/logger.ts
+++ b/packages/helpers/logger.ts
@@ -1,0 +1,24 @@
+const info = (...args: unknown[]): void => {
+  console.info(...args);
+};
+
+const warn = (...args: unknown[]): void => {
+  console.warn(...args);
+};
+
+const error = (...args: unknown[]): void => {
+  console.error(...args);
+};
+
+const debug = (...args: unknown[]): void => {
+  if (process.env.NODE_ENV !== "production") {
+    console.debug(...args);
+  }
+};
+
+export default {
+  debug,
+  error,
+  info,
+  warn
+};


### PR DESCRIPTION
## Summary
- add simple logger helper to replace console
- use logger in redis, lensPg, and API entry

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686557ec73c88330813bace879af5701