### PR TITLE
test: add compressImage helper tests

### DIFF
--- a/apps/web/src/helpers/compressImage.test.ts
+++ b/apps/web/src/helpers/compressImage.test.ts
@@ -1,0 +1,37 @@
+import imageCompression from "browser-image-compression";
+import { describe, expect, it, vi } from "vitest";
+import compressImage from "./compressImage";
+
+vi.mock("browser-image-compression");
+
+describe("compressImage", () => {
+  it("merges provided options with defaults", async () => {
+    const file = new File(["data"], "photo.jpg", { type: "image/jpeg" });
+    const options = { maxSizeMB: 1 };
+    const compressed = new File(["compressed"], "photo.jpg", {
+      type: "image/jpeg"
+    });
+
+    vi.mocked(imageCompression).mockResolvedValueOnce(compressed);
+
+    const result = await compressImage(file, options);
+
+    expect(imageCompression).toHaveBeenCalledWith(file, {
+      exifOrientation: 1,
+      useWebWorker: true,
+      ...options
+    });
+    expect(result).toBe(compressed);
+  });
+
+  it("returns the compressed file from imageCompression", async () => {
+    const file = new File(["f"], "avatar.png", { type: "image/png" });
+    const compressed = new File(["c"], "avatar.png", { type: "image/png" });
+
+    vi.mocked(imageCompression).mockResolvedValueOnce(compressed);
+
+    const result = await compressImage(file, {});
+
+    expect(result).toBe(compressed);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `compressImage` helper to ensure default options

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68661e294b5883308e376a7024fefacf