### PR TITLE
test: simplify helper cases

### DIFF
--- a/packages/helpers/escapeHtml.test.ts
+++ b/packages/helpers/escapeHtml.test.ts
@@ -16,9 +16,4 @@ describe("escapeHtml", () => {
     const text = "Hello World";
     expect(escapeHtml(text)).toBe(text);
   });
-
-  it("escapes each special HTML character individually", () => {
-    const result = escapeHtml("&<>\"'");
-    expect(result).toBe("&amp;&lt;&gt;&quot;&#39;");
-  });
 });

--- a/packages/helpers/getAccount.test.ts
+++ b/packages/helpers/getAccount.test.ts
@@ -3,6 +3,10 @@ import type { AccountFragment } from "@hey/indexer";
 import { describe, expect, it } from "vitest";
 import getAccount from "./getAccount";
 
+const aliceAddress = "0x1234567890abcdef1234567890abcdef12345678";
+const bobAddress = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
+const charlieAddress = "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd";
+
 describe("getAccount", () => {
   it("returns default values when account is undefined", () => {
     const result = getAccount(undefined);
@@ -30,7 +34,7 @@ describe("getAccount", () => {
 
   it("formats lens usernames and sanitizes name", () => {
     const account = {
-      address: "0x1234567890abcdef1234567890abcdef12345678",
+      address: aliceAddress,
       metadata: { name: "Jane\u2714 Doe" },
       owner: "0x01",
       username: {
@@ -49,9 +53,8 @@ describe("getAccount", () => {
   });
 
   it("builds link using address when username is outside lens", () => {
-    const address = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
     const account = {
-      address,
+      address: bobAddress,
       metadata: { name: "Alice" },
       owner: "0x01",
       username: {
@@ -62,7 +65,7 @@ describe("getAccount", () => {
 
     const result = getAccount(account);
     expect(result).toEqual({
-      link: `/account/${address}`,
+      link: `/account/${bobAddress}`,
       name: "Alice",
       username: "alice",
       usernameWithPrefix: "@alice"
@@ -70,16 +73,15 @@ describe("getAccount", () => {
   });
 
   it("uses address when username is missing", () => {
-    const address = "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd";
     const account = {
-      address,
+      address: charlieAddress,
       metadata: { name: "Bob" },
       owner: "0x01"
     } as unknown as AccountFragment;
 
     const result = getAccount(account);
     expect(result).toEqual({
-      link: `/account/${address}`,
+      link: `/account/${charlieAddress}`,
       name: "Bob",
       username: "0xab…abcd",
       usernameWithPrefix: "#0xab…abcd"

--- a/packages/helpers/getAttachmentsData.test.ts
+++ b/packages/helpers/getAttachmentsData.test.ts
@@ -12,17 +12,17 @@ describe("getAttachmentsData", () => {
 
   it("maps attachment fragments to sanitized data", () => {
     const attachments = [
-      { __typename: "MediaImage", item: "ipfs://imgHash" },
+      { __typename: "MediaImage", item: "ipfs://photoCid" },
       {
         __typename: "MediaVideo",
-        cover: "ar://coverHash",
-        item: "ipfs://videoHash"
+        cover: "ar://coverCid",
+        item: "ipfs://clipCid"
       },
       {
         __typename: "MediaAudio",
-        artist: "Artist",
-        cover: "https://ipfs.io/ipfs/coverHash2",
-        item: "lens://audioHash"
+        artist: "DJ Alice",
+        cover: "https://ipfs.io/ipfs/coverCid2",
+        item: "lens://trackCid"
       }
     ];
 
@@ -31,18 +31,18 @@ describe("getAttachmentsData", () => {
     expect(result).toEqual([
       {
         type: "Image",
-        uri: `${IPFS_GATEWAY}/imgHash`
+        uri: `${IPFS_GATEWAY}/photoCid`
       },
       {
-        coverUri: "https://gateway.arweave.net/coverHash",
+        coverUri: "https://gateway.arweave.net/coverCid",
         type: "Video",
-        uri: `${IPFS_GATEWAY}/videoHash`
+        uri: `${IPFS_GATEWAY}/clipCid`
       },
       {
-        artist: "Artist",
-        coverUri: `${IPFS_GATEWAY}/coverHash2`,
+        artist: "DJ Alice",
+        coverUri: `${IPFS_GATEWAY}/coverCid2`,
         type: "Audio",
-        uri: `${STORAGE_NODE_URL}/audioHash`
+        uri: `${STORAGE_NODE_URL}/trackCid`
       }
     ]);
   });

--- a/packages/helpers/getAvatar.test.ts
+++ b/packages/helpers/getAvatar.test.ts
@@ -7,7 +7,7 @@ import {
 import { describe, expect, it } from "vitest";
 import getAvatar from "./getAvatar";
 
-interface TestEntity {
+interface ProfileMock {
   metadata?: {
     picture?: string | null;
     icon?: string | null;
@@ -20,27 +20,27 @@ describe("getAvatar", () => {
   });
 
   it("returns default avatar for invalid picture", () => {
-    const entity: TestEntity = { metadata: { picture: "" } };
+    const entity: ProfileMock = { metadata: { picture: "" } };
     expect(getAvatar(entity)).toBe(DEFAULT_AVATAR);
   });
 
   it("uses icon when picture is missing", () => {
     const url = `${LENS_MEDIA_SNAPSHOT_URL}/icon.png`;
-    const entity: TestEntity = { metadata: { icon: url, picture: null } };
+    const entity: ProfileMock = { metadata: { icon: url, picture: null } };
     const expected = `${LENS_MEDIA_SNAPSHOT_URL}/${TRANSFORMS.AVATAR_SMALL}/icon.png`;
     expect(getAvatar(entity)).toBe(expected);
   });
 
   it("sanitizes ipfs CIDs", () => {
     const cid = `Qm${"a".repeat(44)}`;
-    const entity: TestEntity = { metadata: { picture: cid } };
+    const entity: ProfileMock = { metadata: { picture: cid } };
     const expected = `${IPFS_GATEWAY}/${cid}`;
     expect(getAvatar(entity)).toBe(expected);
   });
 
   it("applies imagekit transform for snapshot urls", () => {
     const url = `${LENS_MEDIA_SNAPSHOT_URL}/path/img.jpg`;
-    const entity: TestEntity = { metadata: { picture: url } };
+    const entity: ProfileMock = { metadata: { picture: url } };
     const expected = `${LENS_MEDIA_SNAPSHOT_URL}/${TRANSFORMS.AVATAR_BIG}/img.jpg`;
     expect(getAvatar(entity, TRANSFORMS.AVATAR_BIG)).toBe(expected);
   });

--- a/packages/helpers/getPostData.test.ts
+++ b/packages/helpers/getPostData.test.ts
@@ -8,18 +8,18 @@ describe("getPostData", () => {
   it("returns content for TextOnlyMetadata", () => {
     const metadata = {
       __typename: "TextOnlyMetadata",
-      content: "hello"
+      content: "Hello world"
     } as unknown as PostMetadataFragment;
 
     const result = getPostData(metadata);
-    expect(result).toEqual({ content: "hello" });
+    expect(result).toEqual({ content: "Hello world" });
   });
 
   it("parses ImageMetadata and sanitizes asset uri", () => {
     const metadata = {
       __typename: "ImageMetadata",
       attachments: undefined,
-      content: "photo",
+      content: "A cool photo",
       image: { item: "ipfs://ipfs/QmImage" }
     } as unknown as PostMetadataFragment;
 
@@ -27,7 +27,7 @@ describe("getPostData", () => {
     expect(result).toEqual({
       asset: { type: "Image", uri: `${ipfsGateway}/QmImage` },
       attachments: [],
-      content: "photo"
+      content: "A cool photo"
     });
   });
 
@@ -37,26 +37,26 @@ describe("getPostData", () => {
       attachments: [
         {
           __typename: "MediaAudio",
-          artist: "DJ",
+          artist: "DJ Alice",
           cover: "ipfs://cover1",
           item: "ipfs://audio1"
         }
       ],
       audio: { artist: undefined, cover: "", item: "" },
-      content: "listen",
+      content: "Listen now",
       title: "My Song"
     } as unknown as PostMetadataFragment;
 
     const result = getPostData(metadata);
     expect(result).toEqual({
       asset: {
-        artist: "DJ",
+        artist: "DJ Alice",
         cover: `${ipfsGateway}/cover1`,
         title: "My Song",
         type: "Audio",
         uri: `${ipfsGateway}/audio1`
       },
-      content: "listen"
+      content: "Listen now"
     });
   });
 

--- a/packages/helpers/imageKit.test.ts
+++ b/packages/helpers/imageKit.test.ts
@@ -19,10 +19,4 @@ describe("imageKit", () => {
     const result = imageKit(original, "tr:w-200");
     expect(result).toBe(`${LENS_MEDIA_SNAPSHOT_URL}/tr:w-200/photo.jpg`);
   });
-
-  it("returns the same url if no transform is provided", () => {
-    const original = `${LENS_MEDIA_SNAPSHOT_URL}/avatar.png`;
-    const result = imageKit(original);
-    expect(result).toBe(original);
-  });
 });

--- a/packages/helpers/sanitizeDStorageUrl.test.ts
+++ b/packages/helpers/sanitizeDStorageUrl.test.ts
@@ -14,23 +14,14 @@ describe("sanitizeDStorageUrl", () => {
     expect(sanitizeDStorageUrl(hash)).toBe(`${ipfsGateway}${hash}`);
   });
 
-  it("converts https://ipfs.io links", () => {
+  it("converts common ipfs url formats", () => {
+    const formats = ["https://ipfs.io/ipfs/", "ipfs://ipfs/", "ipfs://"];
     const hash = `Qm${"b".repeat(44)}`;
-    expect(sanitizeDStorageUrl(`https://ipfs.io/ipfs/${hash}`)).toBe(
-      `${ipfsGateway}${hash}`
-    );
-  });
-
-  it("converts ipfs://ipfs/ links", () => {
-    const hash = `Qm${"c".repeat(44)}`;
-    expect(sanitizeDStorageUrl(`ipfs://ipfs/${hash}`)).toBe(
-      `${ipfsGateway}${hash}`
-    );
-  });
-
-  it("converts ipfs:// links", () => {
-    const hash = `Qm${"d".repeat(44)}`;
-    expect(sanitizeDStorageUrl(`ipfs://${hash}`)).toBe(`${ipfsGateway}${hash}`);
+    for (const prefix of formats) {
+      expect(sanitizeDStorageUrl(`${prefix}${hash}`)).toBe(
+        `${ipfsGateway}${hash}`
+      );
+    }
   });
 
   it("converts lens:// links", () => {


### PR DESCRIPTION
## Summary
- update helper tests with realistic data
- consolidate IPFS sanitizer checks
- remove redundant test coverage and tidy formatting

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686620f582fc8330aa8d7e61bffa7954