### PR TITLE
test: cover nFormatter cases

### DIFF
--- a/apps/web/src/helpers/nFormatter.test.ts
+++ b/apps/web/src/helpers/nFormatter.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import nFormatter from "./nFormatter";
+
+// Tests for nFormatter used in social media contexts
+
+describe("nFormatter", () => {
+  it("formats small follower counts", () => {
+    expect(nFormatter(847)).toBe("847");
+  });
+
+  it("abbreviates thousands with a k", () => {
+    expect(nFormatter(1520)).toBe("1.5k");
+  });
+
+  it("abbreviates millions with an M", () => {
+    expect(nFormatter(2300000)).toBe("2.3M");
+  });
+
+  it("returns empty string for invalid counts", () => {
+    expect(nFormatter(Number.POSITIVE_INFINITY)).toBe("");
+    expect(nFormatter(Number.NaN)).toBe("");
+  });
+});

--- a/apps/web/src/helpers/nFormatter.ts
+++ b/apps/web/src/helpers/nFormatter.ts
@@ -1,4 +1,4 @@
-import humanize from "@/helpers/humanize";
+import humanize from "./humanize";
 
 const LOOKUP = [
   { symbol: "E", value: 1e18 },


### PR DESCRIPTION
## Summary
- add unit tests for nFormatter helper
- import humanize with relative path so vitest can resolve it

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686697c3349083308617cb25d1647e1e