### PR TITLE
test: cover getFavicon helper

### DIFF
--- a/apps/web/src/helpers/getFavicon.test.ts
+++ b/apps/web/src/helpers/getFavicon.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import getFavicon from "./getFavicon";
+
+describe("getFavicon", () => {
+  it("generates favicon URL for social media domain", () => {
+    const result = getFavicon("https://twitter.com/lens");
+    expect(result).toBe(
+      "https://external-content.duckduckgo.com/ip3/twitter.com.ico"
+    );
+  });
+
+  it("handles subdomains correctly", () => {
+    const result = getFavicon("https://m.facebook.com/user");
+    expect(result).toBe(
+      "https://external-content.duckduckgo.com/ip3/m.facebook.com.ico"
+    );
+  });
+
+  it("falls back to unknown domain on invalid URL", () => {
+    const result = getFavicon("not a url");
+    expect(result).toBe(
+      "https://external-content.duckduckgo.com/ip3/unknowndomain.ico"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for getFavicon helper

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686697b0738483309fa6ebcc643082c9