### PR TITLE
test: add prosekit helper tests

### DIFF
--- a/apps/web/src/components/Composer/Actions/CollectSettings/CollectForm.tsx
+++ b/apps/web/src/components/Composer/Actions/CollectSettings/CollectForm.tsx
@@ -7,7 +7,6 @@ import ToggleWithHelper from "@/components/Shared/ToggleWithHelper";
 import { Button } from "@/components/Shared/UI";
 import { useCollectActionStore } from "@/store/non-persisted/post/useCollectActionStore";
 import { usePostLicenseStore } from "@/store/non-persisted/post/usePostLicenseStore";
-import { useAccountStore } from "@/store/persisted/useAccountStore";
 import { EXPANSION_EASE } from "@/variants";
 import AmountConfig from "./AmountConfig";
 import CollectLimitConfig from "./CollectLimitConfig";
@@ -20,7 +19,6 @@ interface CollectFormProps {
 }
 
 const CollectForm = ({ setShowModal }: CollectFormProps) => {
-  const { currentAccount } = useAccountStore();
   const { collectAction, setCollectAction, reset } = useCollectActionStore();
   const { setLicense } = usePostLicenseStore();
 
@@ -84,9 +82,7 @@ const CollectForm = ({ setShowModal }: CollectFormProps) => {
             <AmountConfig setCollectType={setCollectType} />
             {collectAction.payToCollect?.erc20?.value && (
               <SplitConfig
-                isRecipientsDuplicated={
-                  validationChecks.isRecipientsDuplicated
-                }
+                isRecipientsDuplicated={validationChecks.isRecipientsDuplicated}
                 setCollectType={setCollectType}
               />
             )}

--- a/apps/web/src/helpers/prosekit/extension.test.ts
+++ b/apps/web/src/helpers/prosekit/extension.test.ts
@@ -1,0 +1,15 @@
+import { createEditor } from "prosekit/core";
+import { describe, expect, it } from "vitest";
+import { defineEditorExtension } from "./extension";
+
+describe("defineEditorExtension", () => {
+  it("registers mention node and link mark", () => {
+    const extension = defineEditorExtension();
+    const mount = document.createElement("div");
+    const editor = createEditor({ extension });
+    editor.mount(mount);
+    const { schema } = editor.view.state;
+    expect(schema.nodes.mention).toBeDefined();
+    expect(schema.marks.link).toBeDefined();
+  });
+});

--- a/apps/web/src/helpers/prosekit/markdown.test.ts
+++ b/apps/web/src/helpers/prosekit/markdown.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { htmlFromMarkdown, markdownFromHTML } from "./markdown";
+
+const joinHtml = "<p>Hello</p><p>World</p>";
+
+describe("markdown and html conversion", () => {
+  it("converts html to markdown without escaping underscores", () => {
+    const result = markdownFromHTML("<p>hey_world</p>");
+    expect(result).toBe("hey_world\n");
+  });
+
+  it("joins consecutive paragraphs when converting to markdown", () => {
+    const result = markdownFromHTML(joinHtml);
+    expect(result).toBe("Hello\nWorld\n");
+  });
+
+  it("round trips markdown to html", () => {
+    const markdown = "Hello\nWorld";
+    const html = htmlFromMarkdown(markdown);
+    expect(html).toBe("<p>Hello\nWorld</p>\n");
+  });
+});


### PR DESCRIPTION
## Summary
- test markdown and HTML conversions
- verify paragraph joining
- ensure editor extension registers custom schema
- fix unused import in collect settings form

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68695208b4a88330b82c157d303569a6