### PR TITLE
 Remove redundant type annotation in regexLookbehindAvailable IIFE

### DIFF
--- a/packages/data/utils/regexLookbehindAvailable.ts
+++ b/packages/data/utils/regexLookbehindAvailable.ts
@@ -1,4 +1,4 @@
-const regexLookbehindAvailable: boolean = ((): boolean => {
+const regexLookbehindAvailable: boolean = (() => {
   try {
     return "ab".replace(/(?<=a)b/g, "c") === "ac";
   } catch {


### PR DESCRIPTION
Removes the redundant boolean type annotation in the immediately invoked function expression (IIFE) of regexLookbehindAvailable.ts. The type is already specified for the variable itself, making the function return type declaration unnecessary. This change improves code readability while maintaining the same functionality and type safety