### PR TITLE
docs: add instructions for pnpm test

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ Validate the codebase with the TypeScript type checker:
 pnpm typecheck
 ```
 
+### Run tests
+
+Execute unit tests across all workspaces:
+
+```bash
+pnpm test
+```
+
+Each workspace provides its own `vitest.config.ts`, so test behavior is scoped
+to that package. Vitest prints a summary for each workspace showing how many
+files and tests passed along with the execution time.
+
 ### Lint and Format Code
 
 Check code quality and formatting with Biome:


### PR DESCRIPTION
## Summary
- document how to run tests with `pnpm test`
- mention each workspace maintains its own vitest config

## Testing
- `pnpm biome:check`
- `pnpm typecheck` *(fails: apps/api typecheck: Failed)*
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6881d1e448a88330b82d5ee58d7068f9