### PR TITLE
test: add async uuid concurrency

### DIFF
--- a/packages/helpers/generateUUID.test.ts
+++ b/packages/helpers/generateUUID.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import generateUUID from "./generateUUID";
 
+let callCount = 0;
+
+const asyncGenerate = async () => {
+  callCount += 1;
+  return generateUUID();
+};
+
 describe("generateUUID", () => {
+  beforeEach(() => {
+    callCount = 0;
+  });
   it("returns a valid UUID for post identifiers", () => {
     const id = generateUUID();
     const uuidRegex =
@@ -13,5 +23,15 @@ describe("generateUUID", () => {
     const id1 = generateUUID();
     const id2 = generateUUID();
     expect(id1).not.toBe(id2);
+  });
+
+  it("generates unique IDs in concurrent async calls", async () => {
+    const ids = await Promise.all([
+      asyncGenerate(),
+      asyncGenerate(),
+      asyncGenerate()
+    ]);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(callCount).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary
- add a concurrency test for generateUUID

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm typecheck` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6881d289d9b48330ac4ef8cce78f4887