### PR TITLE
docs: fix typos and improve grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## Requirements
 
-To start working with the Hey monorepo, make sure the following tools are installed:
+To start working with the Hey monorepo, ensure the following tools are installed:
 
-- [Node.js](https://nodejs.org/en/download/) (v18 or higher) – the JavaScript runtime used by the project.
-- [pnpm](https://pnpm.io/installation) – the package manager used throughout the repository.
+- [Node.js](https://nodejs.org/en/download/) (v18 or higher) – the JavaScript runtime used in this project.
+- [pnpm](https://pnpm.io/installation) – the package manager used throughout this repository.
 - [Postgres App](https://postgresapp.com/) – the Postgres database used in development.
 
 ## Installation
@@ -54,7 +54,7 @@ Repeat this process for all relevant packages and applications in the monorepo.
 
 ### Environment Variables
 
-The example environment files define the following variables.
+The example environment files define the following variables:
 
 #### API (`apps/api/.env.example`)
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1,6 +1,6 @@
 # Data
 
-Constants, endpoints and shared utilities consumed by the Hey apps.
+Constants, endpoints, and shared utilities consumed by the Hey apps.
 
 ## Commands
 

--- a/packages/indexer/README.md
+++ b/packages/indexer/README.md
@@ -1,6 +1,6 @@
 # Indexer
 
-GraphQL indexer and generated operations for the Hey apps.
+A GraphQL indexer and generated operations for the Hey apps.
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- fix grammar in main README
- tweak wording in data and indexer package docs

## Testing
- `pnpm biome:check`
- `NODE_OPTIONS="--max-old-space-size=4096" pnpm typecheck` *(fails: JavaScript heap out of memory)*
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68826b5ba4108330946a63ecdf3aa1ff