### PR TITLE
fix: use correct follower fragment type

### DIFF
--- a/apps/web/src/components/Account/FollowersYouKnowOverview.tsx
+++ b/apps/web/src/components/Account/FollowersYouKnowOverview.tsx
@@ -1,7 +1,7 @@
 import { TRANSFORMS } from "@hey/data/constants";
 import getAccount from "@hey/helpers/getAccount";
 import getAvatar from "@hey/helpers/getAvatar";
-import { type Follower, useFollowersYouKnowQuery } from "@hey/indexer";
+import { useFollowersYouKnowQuery } from "@hey/indexer";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router";
 import FollowersYouKnow from "@/components/Shared/Modal/FollowersYouKnow";
@@ -34,13 +34,10 @@ const FollowersYouKnowOverview = ({
     }
   });
 
-  const accounts =
-    (data?.followersYouKnow?.items.slice(0, 4) as unknown as Follower[]) || [];
+  const accounts = data?.followersYouKnow?.items.slice(0, 4) ?? [];
 
   const accountNames = useMemo(() => {
-    const names = accounts.map(
-      (account) => getAccount(account.follower as any).name
-    );
+    const names = accounts.map((account) => getAccount(account.follower).name);
     const count = names.length - 3;
 
     if (!names.length) return null;


### PR DESCRIPTION
## Summary
- remove incorrect `as any` cast in `FollowersYouKnowOverview`
- rely on typed query result instead of manual casting

## Testing
- `pnpm biome:check`
- `pnpm build`
- `pnpm test`
- `pnpm typecheck` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68827a110e688330bdec1b520f2bb446