### PR TITLE
test: add og route tests

### DIFF
--- a/apps/api/src/routes/og/getAccount.test.ts
+++ b/apps/api/src/routes/og/getAccount.test.ts
@@ -1,0 +1,27 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockHtml = `<html><head><meta property="og:title" content="Account" /></head></html>`;
+
+vi.mock("./ogUtils", () => ({
+  default: vi.fn(async ({ ctx }) => ctx.html(mockHtml, 200))
+}));
+
+import getAccount from "./getAccount";
+
+describe("getAccount", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = new Hono();
+    app.get("/u/:username", getAccount);
+  });
+
+  it("returns og html", async () => {
+    const res = await app.request("/u/test");
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain("og:title");
+  });
+});

--- a/apps/api/src/routes/og/getGroup.test.ts
+++ b/apps/api/src/routes/og/getGroup.test.ts
@@ -1,0 +1,27 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockHtml = `<html><head><meta property="og:title" content="Group" /></head></html>`;
+
+vi.mock("./ogUtils", () => ({
+  default: vi.fn(async ({ ctx }) => ctx.html(mockHtml, 200))
+}));
+
+import getGroup from "./getGroup";
+
+describe("getGroup", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = new Hono();
+    app.get("/g/:address", getGroup);
+  });
+
+  it("returns og html", async () => {
+    const res = await app.request("/g/0x1234");
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain("og:title");
+  });
+});

--- a/apps/api/src/routes/og/getPost.test.ts
+++ b/apps/api/src/routes/og/getPost.test.ts
@@ -1,0 +1,27 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockHtml = `<html><head><meta property="og:title" content="Post" /></head></html>`;
+
+vi.mock("./ogUtils", () => ({
+  default: vi.fn(async ({ ctx }) => ctx.html(mockHtml, 200))
+}));
+
+import getPost from "./getPost";
+
+describe("getPost", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = new Hono();
+    app.get("/posts/:slug", getPost);
+  });
+
+  it("returns og html", async () => {
+    const res = await app.request("/posts/example");
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain("og:title");
+  });
+});


### PR DESCRIPTION
## Summary
- add route tests for og account, group, and post handlers

## Testing
- `pnpm biome:check`
- `pnpm build`
- `pnpm test`
- `pnpm typecheck` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688771f16ee08330a2692bd00957630a