### PR TITLE
fix: clarify suspended account guideline

### DIFF
--- a/apps/web/src/components/Pages/Guidelines.tsx
+++ b/apps/web/src/components/Pages/Guidelines.tsx
@@ -69,7 +69,7 @@ const Guidelines = () => {
                   <li>Airdrop farming</li>
                 </ul>
                 <p className="leading-7">
-                  If your account got suspended, you are not allowed to create
+                  If your account is suspended, you are not allowed to create
                   any new accounts.
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- clarify that suspended accounts cannot create new accounts

## Testing
- `pnpm biome:check`
- `pnpm typecheck` (fails: apps/api typecheck: Failed, apps/web typecheck: Failed)
- `pnpm build` (fails: apps/web build: Failed)
- `pnpm test` (fails: apps/web test: Failed)


------
https://chatgpt.com/codex/tasks/task_e_6890c1a5b618833091bced92254d7aa6