### PR TITLE
fix: clarify terms page wording

### DIFF
--- a/apps/web/src/components/Pages/Terms.tsx
+++ b/apps/web/src/components/Pages/Terms.tsx
@@ -38,15 +38,14 @@ const Terms = () => {
                   accessing the Site, you consent to the Agreement.
                 </p>
                 <p className="leading-7">
-                  Any new features or tools which are added to Site shall also
-                  be subject to the Terms. You can review the most current
-                  version of the Terms at any time on this page. We reserve the
-                  right to update, change or replace any part of these Terms by
-                  posting updates and/or changes to our Site. It is your
-                  responsibility to check this page periodically for changes.
-                  Your continued use of or access to the Site following the
-                  posting of any changes constitutes acceptance of those
-                  changes.
+                  Any new features or tools which are added to the Site are also
+                  subject to the Terms. You can review the most current version
+                  of the Terms at any time on this page. We reserve the right to
+                  update, change or replace any part of these Terms by posting
+                  updates and/or changes to our Site. It is your responsibility
+                  to check this page periodically for changes. Your continued
+                  use of or access to the Site following the posting of any
+                  changes constitutes acceptance of those changes.
                 </p>
               </div>
               {/* 1. Overview ends */}


### PR DESCRIPTION
## Summary
- clarify wording about new features subject to the Terms

## Testing
- `pnpm biome:check`
- `pnpm typecheck` *(fails: Allocation failed - JavaScript heap out of memory)*
- `pnpm build` *(fails: Rollup annotation error)*
- `pnpm test` *(fails: multiple workspace tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6890c17ecbe4833090477556c7577e02