### PR TITLE
docs: lowercase media references

### DIFF
--- a/apps/web/src/components/Pages/Guidelines.tsx
+++ b/apps/web/src/components/Pages/Guidelines.tsx
@@ -50,7 +50,7 @@ const Guidelines = () => {
                 </ul>
                 <p className="leading-7">
                   Please try to keep Hey family-friendly (especially considering
-                  all Images, Videos, Audios and Links).
+                  images, videos, audio, and links).
                 </p>
               </div>
               {/* Nudity ends */}


### PR DESCRIPTION
## Summary
- use lowercase media references in guidelines

## Testing
- `pnpm biome:check`
- `pnpm typecheck` *(fails: JavaScript heap out of memory)*
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c182c2908330b7a87a1ccf9f2d5d