### PR TITLE
docs: hyphenate content-related actions in terms

### DIFF
--- a/apps/web/src/components/Pages/Terms.tsx
+++ b/apps/web/src/components/Pages/Terms.tsx
@@ -70,7 +70,7 @@ const Terms = () => {
                 </p>
                 <p className="leading-7">
                   The Site allows you to interact with the Lens, including
-                  posts, reposts, comments and other content related actions.
+                  posts, reposts, comments and other content-related actions.
                 </p>
                 <p className="leading-7">
                   We reserve the right - but are not obligated to - limit the


### PR DESCRIPTION
## Summary
- hyphenate "content-related" in terms page for grammar clarity

## Testing
- `pnpm biome:check`
- `pnpm typecheck` *(fails: JavaScript heap out of memory)*
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c1b0a01c8330b8276420f4eecc44