### PR TITLE
perf: window rewards list

### DIFF
--- a/apps/web/src/components/Settings/Rewards/List.tsx
+++ b/apps/web/src/components/Settings/Rewards/List.tsx
@@ -8,6 +8,7 @@ import {
 import dayjs from "dayjs";
 import { useCallback } from "react";
 import { Link } from "react-router";
+import { WindowVirtualizer } from "virtua";
 import Loader from "@/components/Shared/Loader";
 import { EmptyState, ErrorMessage } from "@/components/Shared/UI";
 import useLoadMoreOnIntersect from "@/hooks/useLoadMoreOnIntersect";
@@ -60,29 +61,31 @@ const List = () => {
   }
 
   return (
-    <div className="flex flex-col divide-y divide-gray-200 dark:divide-gray-700">
-      {tokenRewards.map((distribution) => (
-        <div
-          className="flex items-center justify-between p-5"
-          key={distribution.txHash}
-        >
-          <div className="flex items-center space-x-2">
-            <GiftIcon className="size-4 text-gray-500 dark:text-gray-200" />
-            <div>
-              Received <b>{Number(distribution.amount.value).toFixed(4)}</b>
-            </div>
-          </div>
-          <Link
-            className="text-gray-500 text-sm dark:text-gray-200"
-            rel="noreferrer noopener"
-            target="_blank"
-            to={`${BLOCK_EXPLORER_URL}/tx/${distribution.txHash}`}
+    <div className="virtual-divider-list-window">
+      <WindowVirtualizer>
+        {tokenRewards.map((distribution) => (
+          <div
+            className="flex items-center justify-between p-5"
+            key={distribution.txHash}
           >
-            {dayjs(distribution.timestamp).format("MMM D, YYYY h:mm A")}
-          </Link>
-        </div>
-      ))}
-      {hasMore && <span ref={loadMoreRef} />}
+            <div className="flex items-center space-x-2">
+              <GiftIcon className="size-4 text-gray-500 dark:text-gray-200" />
+              <div>
+                Received <b>{Number(distribution.amount.value).toFixed(4)}</b>
+              </div>
+            </div>
+            <Link
+              className="text-gray-500 text-sm dark:text-gray-200"
+              rel="noreferrer noopener"
+              target="_blank"
+              to={`${BLOCK_EXPLORER_URL}/tx/${distribution.txHash}`}
+            >
+              {dayjs(distribution.timestamp).format("MMM D, YYYY h:mm A")}
+            </Link>
+          </div>
+        ))}
+        {hasMore && <span ref={loadMoreRef} />}
+      </WindowVirtualizer>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- window rewards list with `WindowVirtualizer`

## Testing
- `pnpm biome:check`
- `pnpm typecheck` *(fails: Cannot find module '@vitejs/plugin-react'; bigint type error)*
- `pnpm build` *(fails: `LENS_NETWORK` env variable undefined)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689b4c98f0c08330b5c508a1961236c8