### PR TITLE
docs: remove outdated API references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,6 @@ Repeat this process for all relevant packages and applications in the monorepo.
 
 The example environment files define the following variables:
 
-#### API (`apps/api/.env.example`)
-
-- `LENS_NETWORK` – Lens network to use (`mainnet`, `testnet`, or `staging`).
-- `LENS_DATABASE_URL` – Read-only Postgres connection for Lens data.
-- `PRIVATE_KEY` – Private key used to sign Lens requests.
-- `EVER_ACCESS_KEY` – Access key for 4EVERLAND storage.
-- `EVER_ACCESS_SECRET` – Secret key for 4EVERLAND storage.
-- `SHARED_SECRET` – Token for internal API authorization.
-
 #### Web (`apps/web/.env.example`)
 
 - `LENS_NETWORK` – Lens network used by the web app.


### PR DESCRIPTION
## Remove Outdated API References from README

This PR cleans up the README by removing references to the API package that was removed in recent commits.

### Changes Made

- **Removed API Environment Variables Section**: Eliminated the entire `API (apps/api/.env.example)` section since the API package no longer exists
- **Updated Documentation**: Kept only the relevant Web app environment variables
- **Maintained Structure**: Preserved all other sections and formatting

### Context

Based on recent commits (SHA: 54a3abd and d01119b), the API package was removed from the monorepo. However, the README still contained detailed documentation about API environment variables that are no longer relevant.

### Impact

- ✅ **Documentation Accuracy**: README now reflects the current codebase structure
- ✅ **Developer Experience**: Eliminates confusion about non-existent API configuration
- ✅ **Maintenance**: Keeps documentation in sync with code changes
- ✅ **No Breaking Changes**: Only removes outdated information

This is a simple documentation cleanup that ensures new contributors aren't confused by references to removed components.